### PR TITLE
Add plugin_languages_colors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ The default template is `classic`.
     <td data-for="pagespeed">✔️</td>
     <td data-for="isocalendar">✔️</td>
     <td data-for="music">✔️</td>
-    <td data-for="languages">✔️</td>
+    <td data-for="languages"><span title="Use customs colors on @master">✔️<sup>N</sup></span></td>
     <td data-for="followup">✔️</td>
     <td data-for="topics">✔️</td>
     <td data-for="projects">✔️</td>
@@ -1014,6 +1014,22 @@ Add the following to your workflow:
     plugin_languages_ignored: "" # List of comma separated languages to ignore
     plugin_languages_skipped: "" # List of comma separated repositories to skip
 ```
+
+    🚧 Feature below is available as pre-release on @master branch (unstable)
+
+It is possible to use custom colors for languages if those provided by GitHub do not suit you by adding the following to your workflow:
+```yaml
+- uses: lowlighter/metrics@latest
+  with:
+    # ... other options
+    plugin_languages: yes
+    plugin_languages_colors: "0:orange, javascript:#ff0000, ..." # Make most used languages orange and JavaScript red
+```
+
+You can specify either an index with a color, or a language name (case insensitive) with a color.
+Colors can be either in hexadecimal format or a [named color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+
+Use the special value `rainbow` to use rainbow colors.
 
 </details>
 

--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,17 @@ inputs:
     description: List of skipped repositories
     default: ""
 
+  # List of custom colors for specified languages
+  # Use this option when GitHub's color are too similar for your most used languages
+  #
+  # It is possible to use either hexadecimal colors or named colors
+  # - Use "rainbow" values for a predefined set of colors
+  # - Use `${n}:${color}` to change the color of the n-th most used language (e.g. "0:red" to make your most used language red)
+  # - Use `${language}:${color}` to change the color of named language (e.g. "javascript:red" to make JavaScript language red, language case is ignored)
+  plugin_languages_colors:
+    description: Custom languages colors
+    default: ""
+
   # Follow-up plugin
   # Display the number and the ratio of opened/closed issues and opened/merged pull requests on your repositories
   plugin_followup:

--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -166,7 +166,7 @@
           }
         //Languages
           if (plugins.languages.enabled) {
-            for (const option of ["ignored", "skipped"])
+            for (const option of ["ignored", "skipped", "colors"])
               info(`Languages ${option}`, q[`languages.${option}`] = input.array(`plugin_languages_${option}`))
           }
         //Habits

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -44,7 +44,7 @@
           languages.favorites = Object.entries(languages.stats).sort(([an, a], [bn, b]) => b - a).slice(0, 8).map(([name, value]) => ({name, value, color:languages.colors[name], x:0}))
           for (let i = 0; i < languages.favorites.length; i++) {
             languages.favorites[i].x = (languages.favorites[i-1]?.x ?? 0) + (languages.favorites[i-1]?.value ?? 0)
-            if (colors[i])
+            if ((colors[i])&&(!colors[languages.favorites[i].name.toLocaleLowerCase()]))
               languages.favorites[i].color = colors[i]
           }
         //Results

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -12,7 +12,7 @@
           //Skipped repositories
             skipped = decodeURIComponent(skipped).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x)
           //Custom colors
-            if (colors === "rainbow")
+            if (`${colors}` === "rainbow")
               colors = ["0:#ff0000", "1:#ffa500", "2:#ffff00", "3:#008000", "4:#0000ff", "5:#4b0082", "6:#ee82ee", "7:#162221"]
             colors = Object.fromEntries(decodeURIComponent(colors).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x).map(x => x.split(":").map(x => x.trim())))
             console.debug(`metrics/compute/${login}/plugins > languages > custom colors ${JSON.stringify(colors)}`)

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -6,11 +6,16 @@
           if ((!enabled)||(!q.languages))
             return null
         //Parameters override
-          let {"languages.ignored":ignored = "", "languages.skipped":skipped = ""} = q
+          let {"languages.ignored":ignored = "", "languages.skipped":skipped = "", "languages.colors":colors = ""} = q
           //Ignored languages
             ignored = decodeURIComponent(ignored).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x)
           //Skipped repositories
             skipped = decodeURIComponent(skipped).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x)
+          //Custom colors
+            if (colors === "rainbow")
+              colors = ["0:#ff0000", "1:#ffa500", "2:#ffff00", "3:#008000", "4:#0000ff", "5:#4b0082", "6:#ee82ee", "7:#162221"]
+            colors = Object.fromEntries(decodeURIComponent(colors).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x).map(x => x.split(":").map(x => x.trim())))
+            console.debug(`metrics/compute/${login}/plugins > languages > custom colors ${JSON.stringify(colors)}`)
         //Iterate through user's repositories and retrieve languages data
           console.debug(`metrics/compute/${login}/plugins > languages > processing ${data.user.repositories.nodes.length} repositories`)
           const languages = {colors:{}, total:0, stats:{}}
@@ -29,7 +34,7 @@
                   }
                 //Update language stats
                   languages.stats[name] = (languages.stats[name] ?? 0) + size
-                  languages.colors[name] = color ?? "#ededed"
+                  languages.colors[name] = colors[name.toLocaleLowerCase()] ?? color ?? "#ededed"
                   languages.total += size
               }
           }
@@ -37,8 +42,11 @@
           console.debug(`metrics/compute/${login}/plugins > languages > computing stats`)
           Object.keys(languages.stats).map(name => languages.stats[name] /= languages.total)
           languages.favorites = Object.entries(languages.stats).sort(([an, a], [bn, b]) => b - a).slice(0, 8).map(([name, value]) => ({name, value, color:languages.colors[name], x:0}))
-          for (let i = 1; i < languages.favorites.length; i++)
-            languages.favorites[i].x = languages.favorites[i-1].x + languages.favorites[i-1].value
+          for (let i = 0; i < languages.favorites.length; i++) {
+            languages.favorites[i].x = (languages.favorites[i-1]?.x ?? 0) + (languages.favorites[i-1]?.value ?? 0)
+            if (colors[i])
+              languages.favorites[i].color = colors[i]
+          }
         //Results
           return languages
       }

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -138,10 +138,19 @@
       plugin_languages:true,
       plugin_languages_skipped:"metrics",
     }],
+    ["Language plugin (custom color set)", {
+      plugin_languages:true,
+      plugin_languages_colors:"0:ff0000,1:red",
+    }],
+    ["Language plugin (custom color set)", {
+      plugin_languages:true,
+      plugin_languages_colors:"rainbow",
+    }],
     ["Language plugin (complete)", {
       plugin_languages:true,
       plugin_languages_ignored:"html, css, dockerfile",
       plugin_languages_skipped:"metrics",
+      plugin_languages_colors:"rainbow",
     }],
     ["Follow-up plugin (default)", {
       plugin_followup:true,


### PR DESCRIPTION
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please check the following before opening a pull request:
    - It does not duplicate another existing pull request
    - It is not mentioned in https://github.com/lowlighter/metrics/projects/1
      - If it is, ensure that maintainers are aware that you're working on this subject

  Then, explain briefly what your pull request is about and link any related issues (if applicable) to help us keeping track.

  For documentation updates....
    - Check spelling before asking for a review
    - Respect current formatting (check that your editions blends well with current state)
    - Static images must be saved in /.github/readme/imgs and must be of width 1260px
      - UI should always be set in English in screenshots

  For new plugins...
    - Ensure that you created:
      - a plugin entrypoint named index.mjs in /source/plugins
      - tests in /tests/metrics.test.js
        - mocked data if needed (required for all APIs which requires a token or limited in requests)
    - Ensure you updated:
      - /source/app/action/index.mjs to support new plugin options and use correct typing
      - /source/web/statics/* to support new plugin options
      - /settings.example.json with new plugin name
      - README.md to explain new plugin features
    - Include a screenshot in your pull request description
      - You can use `&config.output=png` option in your web instance for it

  For all code editions...
    - Ensure retro-compatibility with previous versions (
        - (unless for unreleased features, for which breaking changes are allowed)
    - Respect current formatting
      - Prefers using appropriate single words for variables and plugins names
      - Avoid using uppercases letters, brackets and semicolons when possible to avoid visual pollution
      - Comments should be added before each "code paragraph" and are considered indent worthy

-->

Add a new option to use custom languages colors