### PR TITLE
Complementary lang colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,7 +1067,7 @@ It is possible to use custom colors for languages if those provided by GitHub do
 You can specify either an index with a color, or a language name (case insensitive) with a color.
 Colors can be either in hexadecimal format or a [named color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
 
-Use the special value `rainbow` to use rainbow colors.
+Use the special value `rainbow` to use rainbow colors. Use `complementary` to use [complementary colors](https://en.wikipedia.org/wiki/Complementary_colors).
 
 </details>
 

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -14,6 +14,9 @@
           //Custom colors
             if (`${colors}` === "rainbow")
               colors = ["0:#ff0000", "1:#ffa500", "2:#ffff00", "3:#008000", "4:#0000ff", "5:#4b0082", "6:#ee82ee", "7:#162221"]
+            if (`${colors}` === "complementary")
+              colors = ["0:#ff0000", "1:#008000", "2:#ffa500", "3:#0000ff", "4:#ffff00", "5:#4b0082", "6:#162221", "7:#ee82ee"]
+             
             colors = Object.fromEntries(decodeURIComponent(colors).split(",").map(x => x.trim().toLocaleLowerCase()).filter(x => x).map(x => x.split(":").map(x => x.trim())))
             console.debug(`metrics/compute/${login}/plugins > languages > custom colors ${JSON.stringify(colors)}`)
         //Iterate through user's repositories and retrieve languages data

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -150,12 +150,14 @@
     ["Language plugin (custom color set)", {
       plugin_languages:true,
       plugin_languages_colors:"rainbow",
+      plugin_languages_colors:"complementary",
     }],
     ["Language plugin (complete)", {
       plugin_languages:true,
       plugin_languages_ignored:"html, css, dockerfile",
       plugin_languages_skipped:"metrics",
       plugin_languages_colors:"rainbow",
+      plugin_languages_colors:"complementary",
     }],
     ["Follow-up plugin (default)", {
       plugin_followup:true,

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -149,7 +149,6 @@
     }],
     ["Language plugin (custom color set)", {
       plugin_languages:true,
-      plugin_languages_colors:"rainbow",
       plugin_languages_colors:"complementary",
     }],
     ["Language plugin (complete)", {
@@ -157,7 +156,6 @@
       plugin_languages_ignored:"html, css, dockerfile",
       plugin_languages_skipped:"metrics",
       plugin_languages_colors:"rainbow",
-      plugin_languages_colors:"complementary",
     }],
     ["Follow-up plugin (default)", {
       plugin_followup:true,


### PR DESCRIPTION
I tried implementing complementary colors as a preset.
I didn't test it in your workflow but I tested the color set on my own page. So you might need to test before merge.

![image](https://user-images.githubusercontent.com/47346598/105579320-1983c900-5d86-11eb-9799-d9d2e4b04030.png)

Maybe my example is not too good because one bar is filling almost everything but you get the idea of complementary colors.

Also I added it to your test file. Not sure if that is right. Might have to check that.

Complementary colors reference: [see here](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Color_star-en_%28tertiary_names%29.svg/1024px-Color_star-en_%28tertiary_names%29.svg.png)



