### PR TITLE
Add basic support for organizations

### DIFF
--- a/source/app/web/instance.mjs
+++ b/source/app/web/instance.mjs
@@ -167,7 +167,7 @@
           catch (error) {
             //Not found user
               if ((error instanceof Error)&&(/^user not found$/.test(error.message))) {
-                console.debug(`metrics/app/${login} > 404 (user not found)`)
+                console.debug(`metrics/app/${login} > 404 (user/organization not found)`)
                 return res.sendStatus(404)
               }
             //Invalid template

--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -1,5 +1,5 @@
 //Setup
-  export default async function ({login, rest, imports, q}, {enabled = false} = {}) {
+  export default async function ({login, rest, q, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
@@ -21,7 +21,7 @@
           console.debug(`metrics/compute/${login}/plugins > activity > ${events.length} events loaded`)
         //Extract activity events
           const activity = events
-            .filter(({actor}) => actor.login === login)
+            .filter(({actor}) => account === "organization" ? true : actor.login === login)
             .filter(({created_at}) => Number.isFinite(days) ? new Date(created_at) > new Date(Date.now()-days*24*60*60*1000) : true)
             .map(({type, payload, repo:{name:repo}}) => {
               //See https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/github-event-types

--- a/source/plugins/gists/index.mjs
+++ b/source/plugins/gists/index.mjs
@@ -1,10 +1,12 @@
 //Setup
-  export default async function ({login, graphql, q, queries}, {enabled = false} = {}) {
+  export default async function ({login, graphql, q, queries, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
           if ((!enabled)||(!q.gists))
             return null
+          if (account === "organization")
+            throw {error:{message:"Not available for organizations"}}
         //Query gists from GitHub API
           const gists = []
           {
@@ -39,6 +41,8 @@
       }
     //Handle errors
       catch (error) {
+        if (error.error?.message)
+          throw error
         throw {error:{message:"An error occured", instance:error}}
       }
   }

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -1,5 +1,5 @@
 //Setup
-  export default async function ({login, rest, imports, data, q}, {enabled = false, from:defaults = 100} = {}) {
+  export default async function ({login, rest, imports, data, q, account}, {enabled = false, from:defaults = 100} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
@@ -28,7 +28,7 @@
         //Get user recent commits
           const commits = events
             .filter(({type}) => type === "PushEvent")
-            .filter(({actor}) => actor.login === login)
+            .filter(({actor}) => account === "organization" ? true : actor.login === login)
             .filter(({created_at}) => new Date(created_at) > new Date(Date.now()-days*24*60*60*1000))
           console.debug(`metrics/compute/${login}/plugins > habits > filtered out ${commits.length} push events over last ${days} days`)
         //Retrieve edited files and filter edited lines (those starting with +/-) from patches

--- a/source/plugins/isocalendar/index.mjs
+++ b/source/plugins/isocalendar/index.mjs
@@ -1,10 +1,12 @@
 //Setup
-  export default async function ({login, graphql, q, queries}, {enabled = false} = {}) {
+  export default async function ({login, graphql, q, queries, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
           if ((!enabled)||(!q.isocalendar))
             return null
+          if (account === "organization")
+            throw {error:{message:"Not available for organizations"}}
         //Parameters override
           let {"isocalendar.duration":duration = "half-year"} = q
           //Duration in days
@@ -83,6 +85,8 @@
       }
     //Handle errors
       catch (error) {
+        if (error.error?.message)
+          throw error
         throw {error:{message:"An error occured", instance:error}}
       }
   }

--- a/source/plugins/lines/index.mjs
+++ b/source/plugins/lines/index.mjs
@@ -1,10 +1,18 @@
 //Setup
-  export default async function ({login, data, imports, rest, q}, {enabled = false} = {}) {
+  export default async function ({login, data, rest, q}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
           if ((!enabled)||(!q.lines))
             return null
+
+        //Context
+          let context = {mode:"user"}
+          if (q.repo) {
+            console.debug(`metrics/compute/${login}/plugins > people > switched to repository mode`)
+            context = {...context, mode:"repository"}
+          }
+
         //Repositories
           const repositories = data.user.repositories.nodes.map(({name:repo, owner:{login:owner}}) => ({repo, owner})) ?? []
         //Get contributors stats from repositories
@@ -18,7 +26,7 @@
               if (!Array.isArray(repository))
                 return
             //Extract author
-              const [contributor] = repository.filter(({author}) => author.login === login)
+              const [contributor] = repository.filter(({author}) => context.mode === "repository" ? true : author.login === login)
             //Compute editions
               if (contributor)
                 contributor.weeks.forEach(({a, d}) => (lines.added += a, lines.deleted += d))

--- a/source/plugins/people/index.mjs
+++ b/source/plugins/people/index.mjs
@@ -9,7 +9,7 @@
         //Context
           let context = {
             mode:"user",
-            types:["followers", "following", "sponsorshipsAsMaintainer", "sponsorshipsAsSponsor", "thanks"],
+            types:account === "organization" ? ["sponsorshipsAsMaintainer", "sponsorshipsAsSponsor", "thanks"] : ["followers", "following", "sponsorshipsAsMaintainer", "sponsorshipsAsSponsor", "thanks"],
             default:"followers, following",
             alias:{followed:"following", sponsors:"sponsorshipsAsMaintainer", sponsored:"sponsorshipsAsSponsor", sponsoring:"sponsorshipsAsSponsor"},
             sponsorships:{sponsorshipsAsMaintainer:"sponsorEntity", sponsorshipsAsSponsor:"sponsorable"}
@@ -52,7 +52,7 @@
                   do {
                     console.debug(`metrics/compute/${login}/plugins > people > retrieving ${type} after ${cursor}`)
                     const {[type]:{edges}} = (
-                      type in context.sponsorships ? (await graphql(queries["people.sponsors"]({login:context.owner ?? login, type, size, after:cursor ? `after: "${cursor}"` : "", target:context.sponsorships[type]}))).user :
+                      type in context.sponsorships ? (await graphql(queries["people.sponsors"]({login:context.owner ?? login, type, size, after:cursor ? `after: "${cursor}"` : "", target:context.sponsorships[type], account})))[account] :
                       context.mode === "repository" ? (await graphql(queries["people.repository"]({login:context.owner, repository:context.repo, type, size, after:cursor ? `after: "${cursor}"` : "", account})))[account].repository :
                       (await graphql(queries.people({login, type, size, after:cursor ? `after: "${cursor}"` : ""}))).user
                     )

--- a/source/plugins/people/index.mjs
+++ b/source/plugins/people/index.mjs
@@ -1,5 +1,5 @@
 //Setup
-  export default async function ({login, data, graphql, rest, q, queries, imports}, {enabled = false} = {}) {
+  export default async function ({login, data, graphql, rest, q, queries, imports, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
@@ -17,7 +17,7 @@
           if (q.repo) {
             console.debug(`metrics/compute/${login}/plugins > people > switched to repository mode`)
             const {owner, repo} = data.user.repositories.nodes.map(({name:repo, owner:{login:owner}}) => ({repo, owner})).shift()
-            context = {...context, mode:"repo", types:["contributors", "stargazers", "watchers", "sponsorshipsAsMaintainer", "thanks"], default:"stargazers, watchers", owner, repo}
+            context = {...context, mode:"repository", types:["contributors", "stargazers", "watchers", "sponsorshipsAsMaintainer", "thanks"], default:"stargazers, watchers", owner, repo}
           }
 
         //Parameters override
@@ -53,7 +53,7 @@
                     console.debug(`metrics/compute/${login}/plugins > people > retrieving ${type} after ${cursor}`)
                     const {[type]:{edges}} = (
                       type in context.sponsorships ? (await graphql(queries["people.sponsors"]({login:context.owner ?? login, type, size, after:cursor ? `after: "${cursor}"` : "", target:context.sponsorships[type]}))).user :
-                      context.mode === "repo" ? (await graphql(queries["people.repository"]({login:context.owner, repository:context.repo, type, size, after:cursor ? `after: "${cursor}"` : ""}))).user.repository :
+                      context.mode === "repository" ? (await graphql(queries["people.repository"]({login:context.owner, repository:context.repo, type, size, after:cursor ? `after: "${cursor}"` : "", account})))[account].repository :
                       (await graphql(queries.people({login, type, size, after:cursor ? `after: "${cursor}"` : ""}))).user
                     )
                     cursor = edges?.[edges?.length-1]?.cursor

--- a/source/plugins/projects/index.mjs
+++ b/source/plugins/projects/index.mjs
@@ -1,5 +1,5 @@
 //Setup
-  export default async function ({login, graphql, q, queries}, {enabled = false} = {}) {
+  export default async function ({login, graphql, q, queries, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
@@ -13,13 +13,13 @@
             limit = Math.max(repositories.length, Math.min(100, Number(limit)))
         //Retrieve user owned projects from graphql api
           console.debug(`metrics/compute/${login}/plugins > projects > querying api`)
-          const {user:{projects}} = await graphql(queries.projects({login, limit}))
+          const {[account]:{projects}} = await graphql(queries.projects({login, limit, account}))
         //Retrieve repositories projects from graphql api
           for (const identifier of repositories) {
             //Querying repository project
               console.debug(`metrics/compute/${login}/plugins > projects > querying api for ${identifier}`)
               const {user, repository, id} = identifier.match(/(?<user>[-\w]+)[/](?<repository>[-\w]+)[/]projects[/](?<id>\d+)/)?.groups
-              const {user:{repository:{project}}} = await graphql(queries["projects.repository"]({user, repository, id}))
+              const {[account]:{repository:{project}}} = await graphql(queries["projects.repository"]({user, repository, id, account}))
             //Adding it to projects list
               console.debug(`metrics/compute/${login}/plugins > projects > registering ${identifier}`)
               project.name = `${project.name} (${user}/${repository})`

--- a/source/plugins/stargazers/index.mjs
+++ b/source/plugins/stargazers/index.mjs
@@ -1,5 +1,5 @@
 //Setup
-  export default async function ({login, graphql, data, q, queries, imports}, {enabled = false} = {}) {
+  export default async function ({login, graphql, data, q, queries}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
@@ -7,16 +7,16 @@
             return null
         //Retrieve stargazers from graphql api
           console.debug(`metrics/compute/${login}/plugins > stargazers > querying api`)
-          const repositories = data.user.repositories.nodes.map(({name}) => name).slice(0, 2)
+          const repositories = data.user.repositories.nodes.map(({name:repository, owner:{login:owner}}) => ({repository, owner})) ?? []
           const dates = []
-          for (const repository of repositories) {
+          for (const {repository, owner} of repositories) {
             //Iterate through stargazers
               console.debug(`metrics/compute/${login}/plugins > stargazers > retrieving stargazers of ${repository}`)
               let cursor = null
               let pushed = 0
               do {
                 console.debug(`metrics/compute/${login}/plugins > stargazers > retrieving stargazers of ${repository} after ${cursor}`)
-                const {repository:{stargazers:{edges}}} = await graphql(queries.stargazers({login, repository, after:cursor ? `after: "${cursor}"` : ""}))
+                const {repository:{stargazers:{edges}}} = await graphql(queries.stargazers({login:owner, repository, after:cursor ? `after: "${cursor}"` : ""}))
                 cursor = edges?.[edges?.length-1]?.cursor
                 dates.push(...edges.map(({starredAt}) => new Date(starredAt)))
                 pushed = edges.length

--- a/source/plugins/stars/index.mjs
+++ b/source/plugins/stars/index.mjs
@@ -1,10 +1,12 @@
 //Setup
-  export default async function ({login, graphql, q, queries, imports}, {enabled = false} = {}) {
+  export default async function ({login, graphql, q, queries, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
           if ((!enabled)||(!q.stars))
             return null
+          if (account === "organization")
+            throw {error:{message:"Not available for organizations"}}
         //Parameters override
           let {"stars.limit":limit = 4} = q
           //Limit
@@ -28,6 +30,8 @@
       }
     //Handle errors
       catch (error) {
+        if (error.error?.message)
+          throw error
         throw {error:{message:"An error occured", instance:error}}
       }
   }

--- a/source/plugins/topics/index.mjs
+++ b/source/plugins/topics/index.mjs
@@ -1,10 +1,12 @@
 //Setup
-  export default async function ({login, imports, q}, {enabled = false} = {}) {
+  export default async function ({login, imports, q, account}, {enabled = false} = {}) {
     //Plugin execution
       try {
         //Check if plugin is enabled and requirements are met
           if ((!enabled)||(!q.topics))
             return null
+          if (account === "organization")
+            throw {error:{message:"Not available for organizations"}}
         //Parameters override
           let {"topics.sort":sort = "stars", "topics.mode":mode = "starred", "topics.limit":limit} = q
           //Shuffle
@@ -85,6 +87,8 @@
       }
     //Handle errors
       catch (error) {
+        if (error.error?.message)
+          throw error
         throw {error:{message:"An error occured", instance:error}}
       }
   }

--- a/source/queries/common.organization.graphql
+++ b/source/queries/common.organization.graphql
@@ -1,0 +1,29 @@
+query MetricsOrganization {
+  organization(login: "$login") {
+    databaseId
+    name
+    login
+    createdAt
+    avatarUrl
+    websiteUrl
+    isVerified
+    twitterUsername
+    repositories(last: 0) {
+      totalCount
+      totalDiskUsage
+      nodes {
+        name
+      }
+    }
+    packages {
+      totalCount
+    }
+		sponsorshipsAsSponsor {
+      totalCount
+    }
+    sponsorshipsAsMaintainer {
+      totalCount
+    }
+
+  }
+}

--- a/source/queries/people.repository.graphql
+++ b/source/queries/people.repository.graphql
@@ -1,5 +1,5 @@
 query PeopleRepository {
-  user(login: "$login") {
+  $account(login: "$login") {
     repository(name: "$repository") {
       $type($after first: 100) {
         edges {

--- a/source/queries/people.sponsors.graphql
+++ b/source/queries/people.sponsors.graphql
@@ -1,5 +1,5 @@
 query PeopleSponsors {
-  user(login: "$login") {
+  $account(login: "$login") {
     login
     $type($after first: 100) {
       edges {

--- a/source/queries/projects.graphql
+++ b/source/queries/projects.graphql
@@ -1,5 +1,5 @@
 query Projects {
-  user(login: "$login") {
+  $account(login: "$login") {
     projects(last: $limit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
       totalCount
       nodes {

--- a/source/queries/projects.repository.graphql
+++ b/source/queries/projects.repository.graphql
@@ -1,5 +1,5 @@
 query RepositoryProject {
-  user(login: "$user") {
+  $account(login: "$user") {
     repository(name: "$repository") {
       project(number: $id) {
         name

--- a/source/queries/repositories.graphql
+++ b/source/queries/repositories.graphql
@@ -1,5 +1,5 @@
 query Repositories {
-  $mode(login: "$login") {
+  $account(login: "$login") {
     repositories($after first: $repositories $forks, orderBy: {field: UPDATED_AT, direction: DESC}) {
       edges {
         cursor

--- a/source/queries/repositories.graphql
+++ b/source/queries/repositories.graphql
@@ -1,5 +1,5 @@
 query Repositories {
-  user(login: "$login") {
+  $mode(login: "$login") {
     repositories($after first: $repositories $forks, orderBy: {field: UPDATED_AT, direction: DESC}) {
       edges {
         cursor

--- a/source/queries/repository.graphql
+++ b/source/queries/repository.graphql
@@ -1,5 +1,5 @@
 query Repository {
-  user(login: "$login") {
+  $mode(login: "$login") {
     repository(name: "$repo") {
       name
       owner {

--- a/source/queries/repository.graphql
+++ b/source/queries/repository.graphql
@@ -1,5 +1,5 @@
 query Repository {
-  $mode(login: "$login") {
+  $account(login: "$login") {
     repository(name: "$repo") {
       name
       owner {

--- a/source/templates/common.mjs
+++ b/source/templates/common.mjs
@@ -1,5 +1,5 @@
 /** Template common processor */
-  export default async function ({login, q, dflags}, {conf, data, rest, graphql, plugins, queries}, {s, pending, imports}) {
+  export default async function ({login, q, dflags}, {conf, data, rest, graphql, plugins, queries, account}, {s, pending, imports}) {
 
     //Init
       const computed = data.computed = {commits:0, sponsorships:0, licenses:{favorite:"", used:{}}, token:{}, repositories:{watchers:0, stargazers:0, issues_open:0, issues_closed:0, pr_open:0, pr_merged:0, forks:0, forked:0, releases:0}}
@@ -32,7 +32,7 @@
         pending.push((async () => {
           try {
             console.debug(`metrics/compute/${login}/plugins > ${name} > started`)
-            data.plugins[name] = await imports.plugins[name]({login, q, imports, data, computed, rest, graphql, queries}, plugins[name])
+            data.plugins[name] = await imports.plugins[name]({login, q, imports, data, computed, rest, graphql, queries, account}, plugins[name])
             console.debug(`metrics/compute/${login}/plugins > ${name} > completed`)
           }
           catch (error) {

--- a/source/templates/repository/template.mjs
+++ b/source/templates/repository/template.mjs
@@ -2,7 +2,7 @@
   import common from "./../common.mjs"
 
 /** Template processor */
-  export default async function ({login, q}, {conf, data, rest, graphql, plugins, queries}, {s, pending, imports}) {
+  export default async function ({login, q}, {conf, data, rest, graphql, plugins, queries, account}, {s, pending, imports}) {
     //Check arguments
       const {repo} = q
       if (!repo) {
@@ -10,12 +10,11 @@
         data.errors.push({error:{message:`You must pass a "repo" argument to use this template`}})
         return await common(...arguments)
       }
-      const mode = data.user.account
-      console.debug(`metrics/compute/${login}/${repo} > switching to mode ${mode}`)
+      console.debug(`metrics/compute/${login}/${repo} > switching to mode ${account}`)
 
     //Retrieving single repository
       console.debug(`metrics/compute/${login}/${repo} > retrieving single repository ${repo}`)
-      const {[mode]:{repository}} = await graphql(queries.repository({login, repo, mode}))
+      const {[account]:{repository}} = await graphql(queries.repository({login, repo, account}))
       data.user.repositories.nodes = [repository]
       data.repo = repository
 


### PR DESCRIPTION
Add basic support for organizations

- [x] Generate metrics for organization
  - [x] Activity plugin (basic support, actor name missing) 
  - [x] Anilist 
  - [x] Follow-up plugin
  - [x] Gists (unsupported)
  - [x] Habits
  - [x] Isocalendar (unsupported)
  - [x] Languages
  - [x] Lines
  - [x] Music
  - [x] PageSpeed (defaults to attached website)
  - [x] People (sponsorships and thanks only, people of organizations missing)    
  - [x] Posts
  - [x] Projects      
  - [x] Stargazers
  - [x] Stars (unsupported)
  - [x] Topics (unsupported)
  - [x] Traffic 
  - [x] Tweets (default to attached twitter username)
- [x] Generate metrics for organization repositories
  - [x] Same features as for user-owned templates 
   
**Fixes**

- [x] Fix an issue with stargazers plugin where it was hardcoded to take only 2 repositories (used for testing)
- [x] Fix an issue with repository template on empty git repository 