### PR TITLE
Add introduction plugin

### DIFF
--- a/source/app/mocks/api/github/graphql/introduction.organization.mjs
+++ b/source/app/mocks/api/github/graphql/introduction.organization.mjs
@@ -1,0 +1,9 @@
+/**Mocked data */
+  export default function({faker, query, login = faker.internet.userName()}) {
+    console.debug("metrics/compute/mocks > mocking graphql api result > introduction/organization")
+    return ({
+      organization:{
+        description:faker.lorem.sentences(),
+      },
+    })
+  }

--- a/source/app/mocks/api/github/graphql/introduction.repository.mjs
+++ b/source/app/mocks/api/github/graphql/introduction.repository.mjs
@@ -1,0 +1,9 @@
+/**Mocked data */
+  export default function({faker, query, login = faker.internet.userName()}) {
+    console.debug("metrics/compute/mocks > mocking graphql api result > introduction/repository")
+    return ({
+      repository:{
+        description:faker.lorem.sentences(),
+      },
+    })
+  }

--- a/source/app/mocks/api/github/graphql/introduction.user.mjs
+++ b/source/app/mocks/api/github/graphql/introduction.user.mjs
@@ -1,0 +1,9 @@
+/**Mocked data */
+  export default function({faker, query, login = faker.internet.userName()}) {
+    console.debug("metrics/compute/mocks > mocking graphql api result > introduction/user")
+    return ({
+      user:{
+        bio:faker.lorem.sentences(),
+      },
+    })
+  }

--- a/source/app/web/statics/app.placeholder.js
+++ b/source/app/web/statics/app.placeholder.js
@@ -175,6 +175,14 @@
                     comments:faker.random.number(1000)
                   }
                 }) : null),
+              //Introduction
+                ...(set.plugins.enabled.introduction ? ({
+                  introduction:{
+                    mode:"user",
+                    title:options["introduction.title"],
+                    text:faker.lorem.sentences(),
+                  }
+                }) : null),
               //Languages
                 ...(set.plugins.enabled.languages ? ({
                   languages:{

--- a/source/plugins/introduction/README.md
+++ b/source/plugins/introduction/README.md
@@ -1,0 +1,26 @@
+### 🙋 Introduction
+
+The *introduction* plugin display your account bio or your organization/repository description.
+It is mostly intended for metrics used outside of GitHub, since these informations are already available on GitHub.
+
+<table>
+  <td align="center">
+    <img src="https://github.com/lowlighter/lowlighter/blob/master/metrics.plugin.introduction.svg">
+    <details><summary>Repository version</summary>
+      <img src="https://github.com/lowlighter/lowlighter/blob/master/metrics.plugin.introduction.repository.svg">
+    </details>
+    <img width="900" height="1" alt="">
+  </td>
+</table>
+
+#### ℹ️ Examples workflows
+
+[➡️ Available options for this plugin](metadata.yml)
+
+```yaml
+- uses: lowlighter/metrics@latest
+  with:
+    # ... other options
+    plugin_introduction: yes
+    plugin_introduction_title: no # Hide section title
+```

--- a/source/plugins/introduction/index.mjs
+++ b/source/plugins/introduction/index.mjs
@@ -1,0 +1,31 @@
+//Setup
+  export default async function({login, q, imports, data, graphql, queries, account}, {enabled = false} = {}) {
+    //Plugin execution
+      try {
+        //Check if plugin is enabled and requirements are met
+          if ((!enabled)||(!q.introduction))
+            return null
+
+        //Load inputs
+          let {title} = imports.metadata.plugins.introduction.inputs({data, account, q})
+
+        //Context
+          let context = {mode:account, login}
+          if (q.repo) {
+            console.debug(`metrics/compute/${login}/plugins > people > switched to repository mode`)
+            const {owner, repo} = data.user.repositories.nodes.map(({name:repo, owner:{login:owner}}) => ({repo, owner})).shift()
+            context = {...context, mode:"repository", owner, repo}
+          }
+
+        //Querying API
+          console.debug(`metrics/compute/${login}/plugins > introduction > querying api`)
+          const text = (await graphql(queries.introduction[context.mode](context)))[context.mode][{user:"bio", organization:"description", repository:"description"}[context.mode]]
+
+        //Results
+          return {mode:context.mode, title, text}
+      }
+    //Handle errors
+      catch (error) {
+        throw {error:{message:"An error occured", instance:error}}
+      }
+  }

--- a/source/plugins/introduction/metadata.yml
+++ b/source/plugins/introduction/metadata.yml
@@ -1,0 +1,20 @@
+name: "🙋 Introduction"
+cost: 1 GraphQL request
+categorie: github
+supports:
+  - user
+  - organization
+  - repository
+inputs:
+
+  # Enable or disable plugin
+  plugin_introduction:
+    description: Display account or repository introduction
+    type: boolean
+    default: no
+
+  # Display introduction section title
+  plugin_introduction_title:
+    description: Display introduction section title
+    type: boolean
+    default: yes

--- a/source/plugins/introduction/queries/organization.graphql
+++ b/source/plugins/introduction/queries/organization.graphql
@@ -1,0 +1,5 @@
+query IntroductionOrganization {
+  organization(login: "$login") {
+    description
+  }
+}

--- a/source/plugins/introduction/queries/repository.graphql
+++ b/source/plugins/introduction/queries/repository.graphql
@@ -1,0 +1,5 @@
+query IntroductionRepository {
+  repository(name: "$repo", owner: "$owner") {
+    description
+  }
+}

--- a/source/plugins/introduction/queries/user.graphql
+++ b/source/plugins/introduction/queries/user.graphql
@@ -1,0 +1,5 @@
+query IntroductionUser {
+  user(login: "$login") {
+    bio
+  }
+}

--- a/source/plugins/introduction/tests.yml
+++ b/source/plugins/introduction/tests.yml
@@ -1,0 +1,12 @@
+- name: Introduction plugin (default)
+  uses: lowlighter/metrics@latest
+  with:
+    token: MOCKED_TOKEN
+    plugin_introduction: yes
+
+- name: Introduction plugin (complete)
+  uses: lowlighter/metrics@latest
+  with:
+    token: MOCKED_TOKEN
+    plugin_introduction: yes
+    plugin_introduction_title: no

--- a/source/templates/classic/partials/_.json
+++ b/source/templates/classic/partials/_.json
@@ -1,5 +1,6 @@
 [
   "base.header",
+  "introduction",
   "base.activity+community",
   "base.repositories",
   "followup",

--- a/source/templates/classic/partials/introduction.ejs
+++ b/source/templates/classic/partials/introduction.ejs
@@ -1,0 +1,26 @@
+<% if (plugins.introduction) { %>
+  <section>
+    <% if (plugins.introduction.title) { %>
+      <h2 class="field">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zM5 8a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zM5.32 9.636a.75.75 0 011.038.175l.007.009c.103.118.22.222.35.31.264.178.683.37 1.285.37.602 0 1.02-.192 1.285-.371.13-.088.247-.192.35-.31l.007-.008a.75.75 0 111.222.87l-.614-.431c.614.43.614.431.613.431v.001l-.001.002-.002.003-.005.007-.014.019a1.984 1.984 0 01-.184.213c-.16.166-.338.316-.53.445-.63.418-1.37.638-2.127.629-.946 0-1.652-.308-2.126-.63a3.32 3.32 0 01-.715-.657l-.014-.02-.005-.006-.002-.003v-.002h-.001l.613-.432-.614.43a.75.75 0 01.183-1.044h.001z"></path></svg>
+        About <%= {user:"me", organization:"us", repository:""}[plugins.introduction.mode] %>
+      </h2>
+    <% } %>
+    <div class="row fill-width" <%- !plugins.introduction.title ? 'style="margin-top: 8px;"' : "" %>>
+      <% if (plugins.introduction.error) { %>
+        <section>
+          <div class="field error">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.343 13.657A8 8 0 1113.657 2.343 8 8 0 012.343 13.657zM6.03 4.97a.75.75 0 00-1.06 1.06L6.94 8 4.97 9.97a.75.75 0 101.06 1.06L8 9.06l1.97 1.97a.75.75 0 101.06-1.06L9.06 8l1.97-1.97a.75.75 0 10-1.06-1.06L8 6.94 6.03 4.97z"></path></svg>
+            <%= plugins.introduction.error.message %>
+          </div>
+        </section>
+      <% } else { %>
+        <section>
+          <div class="introduction">
+            <%= plugins.introduction.text %>
+          </div>
+        </section>
+      <% } %>
+    </div>
+  </section>
+<% } %>

--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -707,6 +707,12 @@
     right: 100%;
   }
 
+/* Introduction */
+  .introduction {
+    white-space: normal;
+    margin: 0 13px 2px;
+  }
+
 /* Fade animation */
   .af {
     opacity: 0;

--- a/source/templates/repository/partials/_.json
+++ b/source/templates/repository/partials/_.json
@@ -1,5 +1,6 @@
 [
   "base.header",
+  "introduction",
   "followup",
   "languages",
   "projects",

--- a/source/templates/repository/partials/introduction.ejs
+++ b/source/templates/repository/partials/introduction.ejs
@@ -1,0 +1,26 @@
+<% if (plugins.introduction) { %>
+  <section>
+    <% if (plugins.introduction.title) { %>
+      <h2 class="field">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zM5 8a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zM5.32 9.636a.75.75 0 011.038.175l.007.009c.103.118.22.222.35.31.264.178.683.37 1.285.37.602 0 1.02-.192 1.285-.371.13-.088.247-.192.35-.31l.007-.008a.75.75 0 111.222.87l-.614-.431c.614.43.614.431.613.431v.001l-.001.002-.002.003-.005.007-.014.019a1.984 1.984 0 01-.184.213c-.16.166-.338.316-.53.445-.63.418-1.37.638-2.127.629-.946 0-1.652-.308-2.126-.63a3.32 3.32 0 01-.715-.657l-.014-.02-.005-.006-.002-.003v-.002h-.001l.613-.432-.614.43a.75.75 0 01.183-1.044h.001z"></path></svg>
+        About <%= {user:"me", organization:"us", repository:""}[plugins.introduction.mode] %>
+      </h2>
+    <% } %>
+    <div class="row fill-width" <%- !plugins.introduction.title ? 'style="margin-top: 8px;"' : "" %>>
+      <% if (plugins.introduction.error) { %>
+        <section>
+          <div class="field error">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.343 13.657A8 8 0 1113.657 2.343 8 8 0 012.343 13.657zM6.03 4.97a.75.75 0 00-1.06 1.06L6.94 8 4.97 9.97a.75.75 0 101.06 1.06L8 9.06l1.97 1.97a.75.75 0 101.06-1.06L9.06 8l1.97-1.97a.75.75 0 10-1.06-1.06L8 6.94 6.03 4.97z"></path></svg>
+            <%= plugins.introduction.error.message %>
+          </div>
+        </section>
+      <% } else { %>
+        <section>
+          <div class="introduction">
+            <%= plugins.introduction.text %>
+          </div>
+        </section>
+      <% } %>
+    </div>
+  </section>
+<% } %>


### PR DESCRIPTION
The *introduction* plugin display your account bio or your organization/repository description.
It is mostly intended for metrics used outside of GitHub, since these informations are already available on GitHub.

![](https://user-images.githubusercontent.com/22963968/108248412-1943d700-7154-11eb-9afb-305b5d9d3e20.png)

![](https://user-images.githubusercontent.com/22963968/108248432-21037b80-7154-11eb-84fa-375d596468a7.png)

