### PR TITLE
Add new option to contributors plugin

### DIFF
--- a/source/app/mocks/api/github/rest/repos/listCommits.mjs
+++ b/source/app/mocks/api/github/rest/repos/listCommits.mjs
@@ -15,6 +15,7 @@
             return this.commit.author
           },
           commit:{
+            message:faker.lorem.sentence(),
             author:{
               name:owner,
               login:faker.internet.userName(),

--- a/source/plugins/contributors/README.md
+++ b/source/plugins/contributors/README.md
@@ -7,6 +7,9 @@ It's especially useful to acknowledge contributors on release notes.
 <table>
   <td align="center">
     <img src="https://github.com/lowlighter/lowlighter/blob/master/metrics.plugin.contributors.svg">
+    <details open><summary>With number of contributions</summary>
+      <img src="https://github.com/lowlighter/lowlighter/blob/master/metrics.plugin.contributors.contributions.svg">
+    </details>
     <img width="900" height="1" alt="">
   </td>
 </table>
@@ -20,7 +23,8 @@ It's especially useful to acknowledge contributors on release notes.
   with:
     # ... other options
     plugin_contributors: yes
-    plugin_contributors_base: ""     # Base reference (commit, tag, branch, etc.)
-    plugin_contributors_head: master # Head reference (commit, tag, branch, etc.)
-    plugin_contributors_ignored: bot # Ignore "bot" user
+    plugin_contributors_base: ""           # Base reference (commit, tag, branch, etc.)
+    plugin_contributors_head: master       # Head reference (commit, tag, branch, etc.)
+    plugin_contributors_ignored: bot       # Ignore "bot" user
+    plugin_contributors_contributions: yes # Display number of contributions for each contributor
 ```

--- a/source/plugins/contributors/README.md
+++ b/source/plugins/contributors/README.md
@@ -22,4 +22,5 @@ It's especially useful to acknowledge contributors on release notes.
     plugin_contributors: yes
     plugin_contributors_base: ""     # Base reference (commit, tag, branch, etc.)
     plugin_contributors_head: master # Head reference (commit, tag, branch, etc.)
+    plugin_contributors_ignored: bot # Ignore "bot" user
 ```

--- a/source/plugins/contributors/index.mjs
+++ b/source/plugins/contributors/index.mjs
@@ -7,7 +7,7 @@
             return null
 
         //Load inputs
-          let {head, base} = imports.metadata.plugins.contributors.inputs({data, account, q})
+          let {head, base, ignored} = imports.metadata.plugins.contributors.inputs({data, account, q})
           const repo = {owner:data.repo.owner.login, repo:data.repo.name}
 
         //Retrieve head and base commits
@@ -50,8 +50,10 @@
         //Compute contributors and contributions
           let contributors = {}
           for (const {author:{login, avatar_url:avatar}} of commits) {
-            if (!login)
+            if ((!login)||(ignored.includes(login))) {
+              console.debug(`metrics/compute/${login}/plugins > contributors > ignored contributor "${login}"`)
               continue
+            }
             if (!(login in contributors))
               contributors[login] = {avatar:avatar ? await imports.imgb64(avatar) : "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mOcOnfpfwAGfgLYttYINwAAAABJRU5ErkJggg==", contributions:0}
             else

--- a/source/plugins/contributors/index.mjs
+++ b/source/plugins/contributors/index.mjs
@@ -7,7 +7,7 @@
             return null
 
         //Load inputs
-          let {head, base, ignored} = imports.metadata.plugins.contributors.inputs({data, account, q})
+          let {head, base, ignored, contributions} = imports.metadata.plugins.contributors.inputs({data, account, q})
           const repo = {owner:data.repo.owner.login, repo:data.repo.name}
 
         //Retrieve head and base commits
@@ -20,7 +20,7 @@
         //Get commit activity
           console.debug(`metrics/compute/${login}/plugins > contributors > querying api for commits between [${ref.base?.abbreviatedOid ?? null}] and [${ref.head?.abbreviatedOid ?? null}]`)
           const commits = []
-          for (let page = 0; ; page++) {
+          for (let page = 1; ; page++) {
             console.debug(`metrics/compute/${login}/plugins > contributors > loading page ${page}`)
             try {
               const {data:loaded} = await rest.repos.listCommits({...repo, per_page:100, page})
@@ -55,7 +55,7 @@
               continue
             }
             if (!(login in contributors))
-              contributors[login] = {avatar:avatar ? await imports.imgb64(avatar) : "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mOcOnfpfwAGfgLYttYINwAAAABJRU5ErkJggg==", contributions:0, pr:[]}
+              contributors[login] = {avatar:avatar ? await imports.imgb64(avatar) : "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mOcOnfpfwAGfgLYttYINwAAAABJRU5ErkJggg==", contributions:1, pr:[]}
             else {
               contributors[login].contributions++
               contributors[login].pr.push(...(message.match(/(?<=[(])#\d+(?=[)])/g) ?? []))
@@ -68,7 +68,7 @@
             contributor.pr = [...new Set(contributor.pr)]
 
         //Results
-          return {head, base, ref, list:contributors}
+          return {head, base, ref, list:contributors, contributions}
       }
     //Handle errors
       catch (error) {

--- a/source/plugins/contributors/metadata.yml
+++ b/source/plugins/contributors/metadata.yml
@@ -22,3 +22,10 @@ inputs:
     description: Head reference
     type: string
     default: master
+
+  # Ignored contributors (useful to ignore bots users)
+  plugin_contributors_ignored:
+    description: Contributors to ignore
+    type: array
+    format: comma-separated
+    default: github-actions[bot]

--- a/source/plugins/contributors/metadata.yml
+++ b/source/plugins/contributors/metadata.yml
@@ -29,3 +29,9 @@ inputs:
     type: array
     format: comma-separated
     default: github-actions[bot]
+
+  # Display total contributions for each contributor
+  plugin_contributors_contributions:
+    description: Display contributions
+    type: boolean
+    default: no

--- a/source/plugins/contributors/tests.yml
+++ b/source/plugins/contributors/tests.yml
@@ -4,10 +4,12 @@
     token: MOCKED_TOKEN
     plugin_contributors: yes
 
-- name: Contributors plugin (default)
+- name: Contributors plugin (complete)
   uses: lowlighter/metrics@latest
   with:
     token: MOCKED_TOKEN
     plugin_contributors: yes
+    plugin_contributors_ignored: github-actions[bot]
+    plugin_contributors_contributions: yes
     plugin_contributors_head: MOCKED_SHA
     plugin_contributors_base: MOCKED_SHA

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -18,7 +18,7 @@
           console.debug(`metrics/compute/${login}/plugins > habits > querying api`)
           const events = []
           try {
-            for (let page = 0; page < pages; page++) {
+            for (let page = 1; page < pages; page++) {
               console.debug(`metrics/compute/${login}/plugins > habits > loading page ${page}`)
               events.push(...(await rest.activity.listEventsForAuthenticatedUser({username:login, per_page:100, page})).data)
             }

--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -700,6 +700,23 @@
   .contributors .label img {
     margin-left: 0;
   }
+  .contributors .contributions {
+    display: flex;
+    align-items: center;
+    font-size: .7rem;
+    margin-left: 6px;
+    margin-right: -10px;
+    background-color: #DDEEFF;
+    padding: 0 7px;
+    border-top-right-radius: 32px;
+    border-bottom-right-radius: 32px;
+  }
+  .contributors .contributions svg {
+    fill: #0366D6;
+    margin-left: 4px;
+    width: .8rem;
+    height: .8rem;
+  }
 
 /* Introduction */
   .introduction {

--- a/source/templates/repository/partials/contributors.ejs
+++ b/source/templates/repository/partials/contributors.ejs
@@ -17,10 +17,13 @@
             <%= plugins.contributors.error.message %>
           </div>
         <% } else { %>
-          <% for (const [login, {avatar}] of Object.entries(plugins.contributors.list)) { %>
+          <% for (const [login, {avatar, contributions}] of Object.entries(plugins.contributors.list)) { %>
             <div class="label">
               <img class="avatar" src="data:image/png;base64,<%= avatar %>" width="22" height="22" alt="" />
               <%= login %>
+              <% if (plugins.contributors.contributions) { %>
+                <div class="contributions"><%= contributions %> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path></svg></div>
+              <% } %>
             </div>
           <% } %>
         <% } %>

--- a/source/templates/repository/template.mjs
+++ b/source/templates/repository/template.mjs
@@ -22,7 +22,7 @@
     //Get commit activity
       console.debug(`metrics/compute/${login}/${repo} > querying api for commits`)
       const commits = []
-      for (let page = 0; page < 100; page++) {
+      for (let page = 1; page < 100; page++) {
         console.debug(`metrics/compute/${login}/${repo} > loading page ${page}`)
         try {
           const {data} = await rest.repos.listCommits({owner:login, repo, per_page:100, page})


### PR DESCRIPTION
- Add `plugin_contributors_ignored` option to ignore users (useful to remove bot users like GitHub Action)
- Add `plugin_contributors_contributions` option to display number of commits per contributors