### PR TITLE
Add plugin_people_sponsors_custom option

### DIFF
--- a/source/plugins/people/README.md
+++ b/source/plugins/people/README.md
@@ -50,6 +50,7 @@ Sections will be ordered the same as specified in `plugin_people_types`.
     plugin_people_limit: 28                    # Limit to 28 entries per section
     plugin_people_size: 28                     # Size in pixels of displayed avatars
     plugin_people_identicons: no               # Use avatars (do not use identicons)
-    plugin_people_thanks: lowlighter, octocat  # Users that will be displayed in "thanks" sections
+    plugin_people_thanks: lowlighter, octocat  # Users that will be displayed in "thanks" section
+    plugin_people_sponsors_custom: octocat     # Users that will be displayed additionally in "sponsors" section
     plugin_people_shuffle: yes                 # Shuffle for varied output
 ```

--- a/source/plugins/people/metadata.yml
+++ b/source/plugins/people/metadata.yml
@@ -57,6 +57,14 @@ inputs:
     format: comma-separated
     default: ""
 
+  # Add specified users to GitHub sponsors ("sponsors" must be specified in "plugin_people_types")
+  # This is useful to list sponsors from unsupported GitHub sponsors sources
+  plugin_people_sponsors_custom:
+    description: Custom GitHub sponsors
+    type: array
+    format: comma-separated
+    default: ""
+
   # Use GitHub identicons instead of users' avatar (for privacy purposes)
   plugin_people_identicons:
     description: Use identicons instead of avatars

--- a/source/plugins/people/tests.yml
+++ b/source/plugins/people/tests.yml
@@ -32,6 +32,14 @@
     plugin_people: yes
     plugin_people_types: sponsors
 
+- name: People plugin (custom sponsors)
+  uses: lowlighter/metrics@latest
+  with:
+    token: MOCKED_TOKEN
+    plugin_people: yes
+    plugin_people_types: sponsors
+    plugin_people_sponsors_custom: lowlighter, octocat
+
 - name: People plugin (stargazers)
   uses: lowlighter/metrics@latest
   with:


### PR DESCRIPTION
Add new option `plugin_people_sponsors_custom` to people plugin to let specify custom sponsors (intended for unsupported GitHub sponsors sources)