### PR TITLE
Feat docker prevuilt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,11 +182,12 @@ inputs:
     description: Use mocked data instead of live APIs
     default: no
   
-  # Use a pre-built image from GitHub registry (experimental)
+  # Use a pre-built image from GitHub registry when using unreleased versions of "lowlighter/metrics"
+  # This option has no effect on forks (images will always be rebuilt from Dockerfile)
   # See https://github.com/users/lowlighter/packages/container/package/metrics for more information
   use_prebuilt_image:
     description: Use pre-built image from GitHub registry
-    default: ""
+    default: yes
   
   # ====================================================================================
   # 📰 Recent activity

--- a/action.yml
+++ b/action.yml
@@ -846,6 +846,7 @@ runs:
   steps:
     - run: |
         # Create environment file from inputs and GitHub variables
+        echo "::group::Metrics docker image setup"
         cd $METRICS_ACTION_PATH
         touch .env
         for INPUT in $(echo $INPUTS | jq -r 'to_entries|map("INPUT_\(.key|ascii_upcase)=\(.value|@uri)")|.[]'); do
@@ -864,20 +865,11 @@ runs:
 
         # Image tag (extracted from version or from env)
         METRICS_TAG=v$(echo $METRICS_VERSION | sed -r 's/^([0-9]+[.][0-9]+).*/\1/')
-        if [[ $METRICS_USE_PREBUILT_IMAGE ]]; then
-          METRICS_TAG=$METRICS_USE_PREBUILT_IMAGE
-          echo "Pre-built image: yes"
-        fi
         echo "Image tag: $METRICS_TAG"
 
         # Image name
-        # Pre-built image
-        if [[ $METRICS_USE_PREBUILT_IMAGE ]]; then
-          echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-          METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
-          docker image pull $METRICS_IMAGE > /dev/null
         # Official action
-        elif [[ $METRICS_SOURCE == "lowlighter" ]]; then
+        if [[ $METRICS_SOURCE == "lowlighter" ]]; then
           # Is released version
           set +e
           METRICS_IS_RELEASED=$(expr $(expr match $METRICS_VERSION .*-beta) == 0)
@@ -887,7 +879,12 @@ runs:
           if [[ "$METRICS_IS_RELEASED" -gt "0" ]]; then
             echo "Using released version $METRICS_TAG, will pull docker image from GitHub registry"
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
-            docker image pull $METRICS_IMAGE > /dev/null
+            docker image pull $METRICS_IMAGE
+          # Use registry for unreleased version with pre-built images
+          elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+            echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
+            docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else
             echo "Using an unreleased version ($METRICS_VERSION)"
@@ -902,15 +899,16 @@ runs:
 
         # Build image if necessary
         set +e
-        docker image inspect $METRICS_IMAGE > /dev/null
+        docker image inspect $METRICS_IMAGE
         METRICS_IMAGE_NEEDS_BUILD="$?"
         set -e
         if [[ "$METRICS_IMAGE_NEEDS_BUILD" -gt "0" ]]; then
           echo "Image $METRICS_IMAGE is not present locally, rebuilding it from Dockerfile"
-          docker build -t $METRICS_IMAGE . > /dev/null
+          docker build -t $METRICS_IMAGE .
         else
           echo "Image $METRICS_IMAGE is present locally"
         fi
+        echo "::endgroup::"
 
         # Run docker image with current environment
         docker run --init --volume $GITHUB_EVENT_PATH:$GITHUB_EVENT_PATH --env-file .env $METRICS_IMAGE

--- a/action.yml
+++ b/action.yml
@@ -883,8 +883,9 @@ runs:
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+            METRICS_TAG="$METRICS_TAG-beta"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG-beta
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/action.yml
+++ b/action.yml
@@ -884,7 +884,7 @@ runs:
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG-beta
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/action.yml
+++ b/action.yml
@@ -886,7 +886,7 @@ runs:
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/action.yml
+++ b/action.yml
@@ -884,6 +884,7 @@ runs:
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
+            echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:
             docker image pull $METRICS_IMAGE

--- a/action.yml
+++ b/action.yml
@@ -882,7 +882,7 @@ runs:
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
-          elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+          elif [[ $METRICS_USE_PREBUILT_IMAGE !~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"

--- a/action.yml
+++ b/action.yml
@@ -882,7 +882,7 @@ runs:
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
-          elif [[ $METRICS_USE_PREBUILT_IMAGE !~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
+          elif [[ ! $METRICS_USE_PREBUILT_IMAGE =~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -64,7 +64,7 @@ runs:
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG-beta
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -63,8 +63,9 @@ runs:
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+            METRICS_TAG="$METRICS_TAG-beta"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG-beta
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -66,7 +66,7 @@ runs:
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-            METRICS_IMAGE=ghcr.io/lowlighter/metrics:
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -64,6 +64,7 @@ runs:
           # Use registry for unreleased version with pre-built images
           elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
+            echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:
             docker image pull $METRICS_IMAGE

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -62,7 +62,7 @@ runs:
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
-          elif [[ $METRICS_USE_PREBUILT_IMAGE !~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
+          elif [[ ! $METRICS_USE_PREBUILT_IMAGE =~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -27,6 +27,7 @@ runs:
   steps:
     - run: |
         # Create environment file from inputs and GitHub variables
+        echo "::group::Metrics docker image setup"
         cd $METRICS_ACTION_PATH
         touch .env
         for INPUT in $(echo $INPUTS | jq -r 'to_entries|map("INPUT_\(.key|ascii_upcase)=\(.value|@uri)")|.[]'); do
@@ -45,20 +46,11 @@ runs:
 
         # Image tag (extracted from version or from env)
         METRICS_TAG=v$(echo $METRICS_VERSION | sed -r 's/^([0-9]+[.][0-9]+).*/\1/')
-        if [[ $METRICS_USE_PREBUILT_IMAGE ]]; then
-          METRICS_TAG=$METRICS_USE_PREBUILT_IMAGE
-          echo "Pre-built image: yes"
-        fi
         echo "Image tag: $METRICS_TAG"
 
         # Image name
-        # Pre-built image
-        if [[ $METRICS_USE_PREBUILT_IMAGE ]]; then
-          echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
-          METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
-          docker image pull $METRICS_IMAGE > /dev/null
         # Official action
-        elif [[ $METRICS_SOURCE == "lowlighter" ]]; then
+        if [[ $METRICS_SOURCE == "lowlighter" ]]; then
           # Is released version
           set +e
           METRICS_IS_RELEASED=$(expr $(expr match $METRICS_VERSION .*-beta) == 0)
@@ -68,7 +60,12 @@ runs:
           if [[ "$METRICS_IS_RELEASED" -gt "0" ]]; then
             echo "Using released version $METRICS_TAG, will pull docker image from GitHub registry"
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
-            docker image pull $METRICS_IMAGE > /dev/null
+            docker image pull $METRICS_IMAGE
+          # Use registry for unreleased version with pre-built images
+          elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+            echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"
+            METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
+            docker image pull $METRICS_IMAGE
           # Rebuild image for unreleased version
           else
             echo "Using an unreleased version ($METRICS_VERSION)"
@@ -83,15 +80,16 @@ runs:
 
         # Build image if necessary
         set +e
-        docker image inspect $METRICS_IMAGE > /dev/null
+        docker image inspect $METRICS_IMAGE
         METRICS_IMAGE_NEEDS_BUILD="$?"
         set -e
         if [[ "$METRICS_IMAGE_NEEDS_BUILD" -gt "0" ]]; then
           echo "Image $METRICS_IMAGE is not present locally, rebuilding it from Dockerfile"
-          docker build -t $METRICS_IMAGE . > /dev/null
+          docker build -t $METRICS_IMAGE .
         else
           echo "Image $METRICS_IMAGE is present locally"
         fi
+        echo "::endgroup::"
 
         # Run docker image with current environment
         docker run --init --volume $GITHUB_EVENT_PATH:$GITHUB_EVENT_PATH --env-file .env $METRICS_IMAGE

--- a/source/app/action/action.yml
+++ b/source/app/action/action.yml
@@ -62,7 +62,7 @@ runs:
             METRICS_IMAGE=ghcr.io/lowlighter/metrics:$METRICS_TAG
             docker image pull $METRICS_IMAGE
           # Use registry for unreleased version with pre-built images
-          elif [[ $METRICS_USE_PREBUILT_IMAGE =~ ^([Tt]rue|[Oo]n|[Yy]es|1)$ ]]; then
+          elif [[ $METRICS_USE_PREBUILT_IMAGE !~ ^([Ff]alse|[Oo]ff|[Nn]o|0)$ ]]; then
             METRICS_TAG="$METRICS_TAG-beta"
             echo "Image tag (updated): $METRICS_TAG"
             echo "Using pre-built version $METRICS_TAG, will pull docker image from GitHub registry"

--- a/source/plugins/core/metadata.yml
+++ b/source/plugins/core/metadata.yml
@@ -210,9 +210,10 @@ inputs:
     type: boolean
     default: no
 
-  # Use a pre-built image from GitHub registry (experimental)
+  # Use a pre-built image from GitHub registry when using unreleased versions of "lowlighter/metrics"
+  # This option has no effect on forks (images will always be rebuilt from Dockerfile)
   # See https://github.com/users/lowlighter/packages/container/package/metrics for more information
   use_prebuilt_image:
     description: Use pre-built image from GitHub registry
-    type: string
-    default: ""
+    type: boolean
+    default: yes


### PR DESCRIPTION
Workflows runs using `lowlighter/metrics@master` will now use the prebuilt docker images from [GitHub container registry](https://github.com/users/lowlighter/packages/container/metrics/versions) instead of rebuilding image which will reduce workflow duration by ~ 5 to 10 minutes.

`use_prebuilt_image` option has been transformed into a boolean (enabled by default)