### PR TITLE
URL support for hashnode posts in recent posts plugin

### DIFF
--- a/source/plugins/posts/index.mjs
+++ b/source/plugins/posts/index.mjs
@@ -41,7 +41,7 @@
                 posts = await Promise.all(posts.map(async({image, ...post}) => ({image:await imports.imgb64(image, {width:144, height:-1}), ...post})))
               }
             //URL post
-              url === 'no' ? url = `https://${user}.hashnode.dev/` : url = url
+              if (url === "no") url = `https://${user}.hashnode.dev/`
             //Results
               return {source, descriptions, covers, list:posts, url}
           }

--- a/source/plugins/posts/index.mjs
+++ b/source/plugins/posts/index.mjs
@@ -7,8 +7,7 @@
             return null
 
         //Load inputs
-          let {source, descriptions, covers, limit, user} = imports.metadata.plugins.posts.inputs({data, account, q})
-
+          let {source, descriptions, covers, limit, user, url} = imports.metadata.plugins.posts.inputs({data, account, q})
         //Retrieve posts
           console.debug(`metrics/compute/${login}/plugins > posts > processing with source ${source}`)
           let posts = null
@@ -21,7 +20,7 @@
               }
             //Hashnode
               case "hashnode":{
-                posts = (await imports.axios.post("https://api.hashnode.com", {query:queries.posts.hashnode({user})}, {headers:{"Content-type":"application/json"}})).data.data.user.publication.posts.map(({title, brief:description, dateAdded:date, coverImage:image}) => ({title, description, date, image}))
+                posts = (await imports.axios.post("https://api.hashnode.com", {query:queries.posts.hashnode({user})}, {headers:{"Content-type":"application/json"}})).data.data.user.publication.posts.map(({title, brief:description, dateAdded:date, coverImage:image, slug:slug}) => ({title, description, date, image, slug}))
                 break
               }
             //Unsupported
@@ -41,8 +40,10 @@
                 console.debug(`metrics/compute/${login}/plugins > posts > formatting cover images`)
                 posts = await Promise.all(posts.map(async({image, ...post}) => ({image:await imports.imgb64(image, {width:144, height:-1}), ...post})))
               }
+            //URL post
+              url === 'no' ? url = `https://${user}.hashnode.dev/` : url = url
             //Results
-              return {source, descriptions, covers, list:posts}
+              return {source, descriptions, covers, list:posts, url}
           }
 
         //Unhandled error

--- a/source/plugins/posts/metadata.yml
+++ b/source/plugins/posts/metadata.yml
@@ -48,3 +48,8 @@ inputs:
     type: string
     default: .user.login
 
+  # Custom URL
+  plugin_posts_url:
+    description: Posts custom url
+    type: string
+    default: no

--- a/source/plugins/posts/queries/hashnode.graphql
+++ b/source/plugins/posts/queries/hashnode.graphql
@@ -1,11 +1,12 @@
 query PostsHashnode {
-  user(username: "$user"){
-    publication{
-      posts(page: 1) {
+  user(username: "$user") {
+    publication {
+      posts(page: 0) {
         title
         brief
         coverImage
         dateAdded
+        slug
       }
     }
   }

--- a/source/templates/classic/partials/posts.ejs
+++ b/source/templates/classic/partials/posts.ejs
@@ -17,7 +17,7 @@
             From <%= plugins.posts.source %>
           </div>
           <% if (plugins.posts.list.length) { %>
-            <% for (const {title, description, image, date} of plugins.posts.list) { %>
+            <% for (const {title, description, image, date, url, slug} of plugins.posts.list) { %>
               <div class="field post">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M4.75 0a.75.75 0 01.75.75V2h5V.75a.75.75 0 011.5 0V2h1.25c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V3.75C1 2.784 1.784 2 2.75 2H4V.75A.75.75 0 014.75 0zm0 3.5h8.5a.25.25 0 01.25.25V6h-11V3.75a.25.25 0 01.25-.25h2zm-2.25 4v6.75c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V7.5h-11z"></path></svg>
                 <div class="infos">
@@ -28,10 +28,12 @@
                     <% } %>
                   </div>
                   <div class="right">
-                    <div class="title"><%= title %></div>
-                    <% if (plugins.posts.descriptions) { %>
-                      <div class="description"><%= description %></div>
-                    <% } %>
+                    <a href="<%= plugins.posts.url %><%= slug %>">
+                      <div class="title"><%= title %></div>
+                      <% if (plugins.posts.descriptions) { %>
+                        <div class="description"><%= description %></div>
+                      <% } %>
+                    </a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Hi, I made some improvements to the recent posts plugin specifically for hashnode.

## URL Support
First add the option **Posts custom url** where a custom url can be inserted if required.
![scrnli_4_4_2021_5-54-21 PM](https://user-images.githubusercontent.com/57654255/113523832-02283f80-9570-11eb-85ec-140d29a97ae3.png)

If the previous option has the value "no" then the url will be "https://USER.hashnode.dev/" (USER will be replaced by the provided github user)

The generated url will be inserted in the title and description of each post to create a link to the post.

![scrnli_4_4_2021_6-08-37 PM](https://user-images.githubusercontent.com/57654255/113523925-ce99e500-9570-11eb-8129-9812f4a7f59d.png)

## Minor change in GraphQL Query
In the query the page had the value 1. This will show the publications from the tenth which does not meet the purpose of the plugin.

Just change from 1 to 0 so that it shows exactly the most recent posts.

This change is too simple, but I had to explain it.

``` graphql
query PostsHashnode {
  user(username: "$user") {
    publication {
      posts(page: 0) {
        title
        brief
        coverImage
        dateAdded
        slug
      }
    }
  }
}
```