### PR TITLE
Improve token error msg

### DIFF
--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -108,6 +108,7 @@
             const {headers} = await api.rest.request("HEAD /")
             if (!("x-oauth-scopes" in headers))
               throw new Error("GitHub API did not send any \"x-oauth-scopes\" header back from provided \"token\". It means that your token may not be valid or you're using GITHUB_TOKEN which cannot be used since metrics will fetch data outside of this repository scope. Use a personal access token instead (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations).")
+            info("Token validity", "seems ok")
           }
         //Extract octokits
           const {graphql, rest} = api

--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -91,7 +91,7 @@
         //Token for data gathering
           info("GitHub token", token, {token:true})
           if (!token)
-            throw new Error('You must provide a valid GitHub personal token to gather your metrics (see "How to setup?" section at https://github.com/lowlighter/metrics#%EF%B8%8F-using-github-action-on-your-profile-repository-5-min-setup)')
+            throw new Error("You must provide a valid GitHub personal token to gather your metrics (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations)")
           conf.settings.token = token
           const api = {}
           api.graphql = octokit.graphql.defaults({headers:{authorization:`token ${token}`}})
@@ -102,6 +102,18 @@
           if (mocked) {
             Object.assign(api, await mocks(api))
             info("Use mocked API", true)
+          }
+        //Test token validity
+          else if (!/^(?:MOCKED_TOKEN|NOT_NEEDED)$/.test(token)) {
+            try {
+              const {headers} = await api.rest.request("HEAD /")
+              if (!("x-oauth-scopes" in headers))
+                throw new Error("No x-oauth-scopes header found when using token")
+            }
+            catch (error) {
+              console.debug(error)
+              console.log("::warning::GitHub API did not send any \"x-oauth-scopes\" header back from provided \"token\". It means that your token may not be valid or you're using GITHUB_TOKEN which cannot be used since metrics will fetch data outside of this repository scope. Use a personal access token instead (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations).")
+            }
           }
         //Extract octokits
           const {graphql, rest} = api

--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -112,7 +112,7 @@
             }
             catch (error) {
               console.debug(error)
-              console.log("::warning::GitHub API did not send any \"x-oauth-scopes\" header back from provided \"token\". It means that your token may not be valid or you're using GITHUB_TOKEN which cannot be used since metrics will fetch data outside of this repository scope. Use a personal access token instead (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations).")
+              throw new Error("GitHub API did not send any \"x-oauth-scopes\" header back from provided \"token\". It means that your token may not be valid or you're using GITHUB_TOKEN which cannot be used since metrics will fetch data outside of this repository scope. Use a personal access token instead (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations).")
             }
           }
         //Extract octokits

--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -105,15 +105,9 @@
           }
         //Test token validity
           else if (!/^(?:MOCKED_TOKEN|NOT_NEEDED)$/.test(token)) {
-            try {
-              const {headers} = await api.rest.request("HEAD /")
-              if (!("x-oauth-scopes" in headers))
-                throw new Error("No x-oauth-scopes header found when using token")
-            }
-            catch (error) {
-              console.debug(error)
+            const {headers} = await api.rest.request("HEAD /")
+            if (!("x-oauth-scopes" in headers))
               throw new Error("GitHub API did not send any \"x-oauth-scopes\" header back from provided \"token\". It means that your token may not be valid or you're using GITHUB_TOKEN which cannot be used since metrics will fetch data outside of this repository scope. Use a personal access token instead (see https://github.com/lowlighter/metrics/blob/master/.github/readme/partials/setup/action/setup.md for more informations).")
-            }
           }
         //Extract octokits
           const {graphql, rest} = api


### PR DESCRIPTION
This will send a test request before rendering to verify that given token is valid and can be used.

Using a `HEAD` request, it'll check whether it throws a `401 Bad credentials` (i.e. invalid token) or a response without `x-oauth-scopes` header (meaning that `GITHUB_TOKEN` has probably be used instead)