### PR TITLE
Condense merge commits

### DIFF
--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -108,7 +108,7 @@
                     case "PushEvent":{
                       let {size, commits, ref} = payload
                       if (commits[commits.length-1].message.startsWith("Merge branch "))
-                        commits = commits[commits.length-1]
+                        commits = [commits[commits.length-1]]
                       return {type:"push", actor, timestamp, repo, size, branch:ref.match(/refs.heads.(?<branch>.*)/)?.groups?.branch ?? null, commits:commits.map(({sha, message}) => ({sha:sha.substring(0, 7), message}))}
                     }
                   //Released
@@ -143,4 +143,3 @@
         throw {error:{message:"An error occured", instance:error}}
       }
   }
-

--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -107,6 +107,8 @@
                   //Pushed commits
                     case "PushEvent":{
                       const {size, commits, ref} = payload
+                      if (commits[commits.length-1].message.startsWith("Merge branch "))
+                        commits = commits[commits.length-1]
                       return {type:"push", actor, timestamp, repo, size, branch:ref.match(/refs.heads.(?<branch>.*)/)?.groups?.branch ?? null, commits:commits.map(({sha, message}) => ({sha:sha.substring(0, 7), message}))}
                     }
                   //Released

--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -106,7 +106,7 @@
                     }
                   //Pushed commits
                     case "PushEvent":{
-                      const {size, commits, ref} = payload
+                      let {size, commits, ref} = payload
                       if (commits[commits.length-1].message.startsWith("Merge branch "))
                         commits = commits[commits.length-1]
                       return {type:"push", actor, timestamp, repo, size, branch:ref.match(/refs.heads.(?<branch>.*)/)?.groups?.branch ?? null, commits:commits.map(({sha, message}) => ({sha:sha.substring(0, 7), message}))}


### PR DESCRIPTION
Condense the list of commits produced by a PushEvent to only the final merge commit if it is present. Resolve #241.