### PR TITLE
Reverse order of commits listed in a recent activity entry

### DIFF
--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -107,7 +107,7 @@
                   //Pushed commits
                     case "PushEvent":{
                       const {size, commits, ref} = payload
-                      return {type:"push", actor, timestamp, repo, size, branch:ref.match(/refs.heads.(?<branch>.*)/)?.groups?.branch ?? null, commits:commits.map(({sha, message}) => ({sha:sha.substring(0, 7), message}))}
+                      return {type:"push", actor, timestamp, repo, size, branch:ref.match(/refs.heads.(?<branch>.*)/)?.groups?.branch ?? null, commits:commits.reverse().map(({sha, message}) => ({sha:sha.substring(0, 7), message}))}
                     }
                   //Released
                     case "ReleaseEvent":{


### PR DESCRIPTION
The recent activity plugin lists items in reverse chronological order, so this makes the commits shown in an item match that order.

From https://github.com/lowlighter/metrics/issues/241#issuecomment-822362233 by lowlighter.