### PR TITLE
Add `plugin_lines_skipped` option

### DIFF
--- a/source/plugins/lines/index.mjs
+++ b/source/plugins/lines/index.mjs
@@ -7,7 +7,7 @@
             return null
 
         //Load inputs
-          imports.metadata.plugins.lines.inputs({data, account, q})
+          let {skipped} = imports.metadata.plugins.lines.inputs({data, account, q})
 
         //Context
           let context = {mode:"user"}
@@ -22,8 +22,7 @@
         //Get contributors stats from repositories
           console.debug(`metrics/compute/${login}/plugins > lines > querying api`)
           const lines = {added:0, deleted:0}
-          const response = await Promise.all(repositories.map(({repo, owner}) => rest.repos.getContributorsStats({owner, repo})))
-
+          const response = await Promise.all(repositories.map(({repo, owner}) => (skipped.includes(repo.toLocaleLowerCase()))||(skipped.includes(`${owner}/${repo}`)) ? {} : rest.repos.getContributorsStats({owner, repo})))
         //Compute changed lines
           console.debug(`metrics/compute/${login}/plugins > lines > computing total diff`)
           response.map(({data:repository}) => {

--- a/source/plugins/lines/metadata.yml
+++ b/source/plugins/lines/metadata.yml
@@ -13,3 +13,11 @@ inputs:
     description: Display lines of code metrics
     type: boolean
     default: no
+
+  # List of repositories that will be skipped
+  plugin_lines_skipped:
+    description: Repositories to skip
+    type: array
+    format: comma-separated
+    default: ""
+    example: my-repo-1, my-repo-2, owner/repo-3 ...


### PR DESCRIPTION
Add `plugin_lines_skipped` option to ignore selected repositories from line count (see #247)