### PR TITLE
Simplify GitHub URLs in comments

### DIFF
--- a/source/app/web/statics/about/index.html
+++ b/source/app/web/statics/about/index.html
@@ -190,7 +190,7 @@
                       <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.75 2.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.75.75 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75zM1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.457 1.457 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5z"></path></svg>
                       <div class="content">
                         Commented on <a :href="`https://github.com/${repo}/${{issue:'issues', pr:'pull', commit:'commit'}[event.on]}/${event.number}`">#{{ event.number }} {{ event.title }}</a> from <a :href="`https://github.com/${repo}`">{{ repo }}</a>
-                        <quote v-if="event.content.trim().length" v-html="event.content"></quote>
+                        <quote v-if="event.content.trim().length" v-html="format('comment', event.content, {repo})"></quote>
                       </div>
                     </template>
                     <template v-if="type === 'member'">

--- a/source/app/web/statics/about/index.html
+++ b/source/app/web/statics/about/index.html
@@ -227,14 +227,14 @@
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"></path></svg>
                       <div class="content">
                         {{ event.action === "opened" ? "Opened" : event.action === "reopened" ? "Reopened" : "Closed" }} <a :href="`https://github.com/${repo}/issues/${event.number}`">#{{ event.number }} {{ event.title }}</a> in <a :href="`https://github.com/${repo}`">{{ repo }}</a>
-                        <quote v-if="event.content.trim().length" v-html="event.content"></quote>
+                        <quote v-if="event.content.trim().length" v-html="format('comment', event.content, {repo})"></quote>
                       </div>
                     </template>
                     <template v-if="type === 'pr'">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"></path></svg>
                       <div class="content">
                         {{ event.action === "opened" ? "Opened" : event.action === "merged" ? "Merged" : "Closed" }} <a :href="`https://github.com/${repo}/pull/${event.number}`">#{{ event.number }} {{ event.title }}</a> in <a :href="`https://github.com/${repo}`">{{ repo }}</a>
-                        <quote v-if="event.content.trim().length" v-html="event.content"></quote>
+                        <quote v-if="event.content.trim().length" v-html="format('comment', event.content, {repo})"></quote>
                         <ul>
                           <li>
                             {{ event.files.changed }} file{{ "s" }} changed <code>++{{ event.lines.added }} --{{ event.lines.deleted }}</code>

--- a/source/app/web/statics/about/script.js
+++ b/source/app/web/statics/about/script.js
@@ -56,15 +56,20 @@
               case "date":
                 return new Intl.DateTimeFormat(navigator.lang, options).format(new Date(value))
               case "comment":
+                const baseUrl = String.raw`https?:\/\/(?:www\.)?github.com\/([\w.-]+\/[\w.-]+)\/`
                 return value
                   .replace(
-                    /https?:\/\/(?:www\.)?github.com\/([\w.-]+\/[\w.-]+)\/[\w.-]+\/(\d+)(?:\?\S+)?(#\S+)?/g,
+                    RegExp(baseUrl + String.raw`(?:issues|pull|discussions)\/(\d+)(?:\?\S+)?(#\S+)?`, 'g'),
                     (_, repo, id, comment) => (options?.repo === repo ? '' : repo) + `#${id}` + (comment ? ` (comment)` : '')
                   ) // -> 'lowlighter/metrics#123'
                   .replace(
-                    /(?:https?:\/\/(?:www\.)?github.com\/([\w.-]+\/[\w.-]+))?\/commit\/([\da-f]+)/g,
+                    RegExp(baseUrl + String.raw`commit\/([\da-f]+)`, 'g'),
                     (_, repo, sha) => (options?.repo === repo ? '' : repo + '@') + sha
                   ) // -> 'lowlighter/metrics@123abc'
+                  .replace(
+                    RegExp(baseUrl + String.raw`compare\/(\S+...\S+)`, 'g'),
+                    (_, repo, tags) => (options?.repo === repo ? '' : repo + '@') + tags
+                  ) // -> 'lowlighter/metrics@1.0...1.1'
             }
             return value
           },

--- a/source/app/web/statics/about/script.js
+++ b/source/app/web/statics/about/script.js
@@ -55,6 +55,16 @@
                 return new Intl.NumberFormat(navigator.lang, options).format(value)
               case "date":
                 return new Intl.DateTimeFormat(navigator.lang, options).format(new Date(value))
+              case "comment":
+                return value
+                  .replace(
+                    /https?:\/\/(?:www\.)?github.com\/([\w.-]+\/[\w.-]+)\/[\w.-]+\/(\d+)(?:\?\S+)?(#\S+)?/g,
+                    (_, repo, id, comment) => (options?.repo === repo ? '' : repo) + `#${id}` + (comment ? ` (comment)` : '')
+                  ) // -> 'lowlighter/metrics#123'
+                  .replace(
+                    /(?:https?:\/\/(?:www\.)?github.com\/([\w.-]+\/[\w.-]+))?\/commit\/([\da-f]+)/g,
+                    (_, repo, sha) => (options?.repo === repo ? '' : repo + '@') + sha
+                  ) // -> 'lowlighter/metrics@123abc'
             }
             return value
           },


### PR DESCRIPTION
Resolve #254 

Turns links such as `https://github.com/lowlighter/metrics/issues/254` into `lowlighter/metrics#254` or `#254` depending on the repository.
Applies to both issues/PRs and commits.