### PR TITLE
Release v3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.8.0-beta",
+  "version": "3.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.8.0-beta",
+      "version": "3.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.8.0-beta",
+  "version": "3.8.0",
   "description": "An image generator with 20+ metrics about your GitHub account such as activity, community, repositories, coding habits, website performances, music played, starred topics, etc. that you can put on your profile or elsewhere !",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## 📦 New features

* ✨ **Metrics insights**
  * #237 Improved markdown and code snippets rendering 
  * #237 Empty comments are not displayed anymore
  * #262 GitHub urls for comments, issues and pull requests are now rendered with GitHub format
* 🎩 **Notable contributions**
  * #240 Add support for `plugin_notable_filter` to filter contributions (based on GitHub search query filter)
  * #240 Add support for `plugin_notable_repositories` to also display repository name along with organization name
  * <img src="https://user-images.githubusercontent.com/22963968/115153409-fd867f80-a075-11eb-9182-2893174fa709.png" width="400">
* 📰 **Recent activity**
  * #237 Improved markdown and code snippets rendering 
  * #242 Merge commits now display as a single commit
  * #244 Pushed commits are now display from most recent to oldest for more readability
* 🗨️ **Stackoverflow plugin**
  * #237 Improved markdown and code snippets rendering 
  * #237 Use `plugin_stackoverflow_lines_snippet` to configure how many lines should be displayed
* 🎭 **Comment reactions** 
  * #256 Add `plugin_reactions_ignored` to ignore reactions of user (defaults to `github-actions[bot], dependabot[bot]`) 
* 🏅 **Repository contributors** 
  * #256 `dependabot[bot]` user is now ignored by default 
* 📒 **Markdown template**
  * #263 SVG plugins can now directly be embed in a tempate without the need of creating separated jobs
    * Use `<%- await embed({isocalendar:true}) %>`  to include an isocalendar for example
    * Rendered images are pushed to `markdown_cache` folder (defaults to `.cache`)
  * #270 This template can now be rendered as PDF file by using `config_output: markdown-pdf` 
* 🦑 **Miscelleanous**
  * #238 Add support for `extras_css` option to let users inject raw CSS without template edition
    * For heavy styling, consider using [community templates](https://github.com/lowlighter/metrics/blob/master/source/templates/community/README.md) instead  
  * #272 `filename` extension is now automatically deduced based on `config_output` value
  * #273 `config_output` now defaults to `"auto"` which will use the prefered template output (e.g. `svg` for *classic*, *repository* and *terminal* templates and `markdown` for *markdown*)
  * #273 Template now define which account type and output formats are supported and will throw an error in case of incompatibility
  * #273 Community templates can now use a `template.mjs` fallback from any official templates rather than just the *classic* one

## 🧰 Fixes

* #243 Fix `No commits between` error when a run resulted in no diff and tried to open a new pull request

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/lowlighter/master/metrics.sponsors.svg">
