### PR TITLE
Add selfhosted wakatime integration (wakapi)

### DIFF
--- a/source/plugins/wakatime/index.mjs
+++ b/source/plugins/wakatime/index.mjs
@@ -6,7 +6,7 @@ export default async function ({ login, q, imports, data, account },{ enabled = 
     if (!enabled || !q.wakatime) return null;
 
     //Load inputs
-    let { sections, days, limit, apiurl, user } = imports.metadata.plugins.wakatime.inputs({ data, account, q });
+    let { sections, days, limit, url, user } = imports.metadata.plugins.wakatime.inputs({ data, account, q });
     if (!limit) limit = void limit;
     const range =
       {

--- a/source/plugins/wakatime/index.mjs
+++ b/source/plugins/wakatime/index.mjs
@@ -18,7 +18,7 @@ export default async function ({ login, q, imports, data, account },{ enabled = 
 
     //Querying api and format result (https://wakatime.com/developers#stats)
     console.debug(`metrics/compute/${login}/plugins > wakatime > querying api`);
-    const {data: { data: stats }} = await imports.axios.get(`${apiurl}/api/v1/users/${user}/stats/${range}?api_key=${token}`);
+    const {data: { data: stats }} = await imports.axios.get(`${url}/api/v1/users/${user}/stats/${range}?api_key=${token}`);
     const result = {
       sections,
       days,

--- a/source/plugins/wakatime/index.mjs
+++ b/source/plugins/wakatime/index.mjs
@@ -6,14 +6,7 @@ export default async function ({ login, q, imports, data, account },{ enabled = 
     if (!enabled || !q.wakatime) return null;
 
     //Load inputs
-    let {
-      sections,
-      days,
-      limit,
-      apiurl,
-      wakapi = false,
-      user = "current",
-    } = imports.metadata.plugins.wakatime.inputs({ data, account, q });
+    let { sections, days, limit, apiurl, user } = imports.metadata.plugins.wakatime.inputs({ data, account, q });
     if (!limit) limit = void limit;
     const range =
       {
@@ -25,9 +18,7 @@ export default async function ({ login, q, imports, data, account },{ enabled = 
 
     //Querying api and format result (https://wakatime.com/developers#stats)
     console.debug(`metrics/compute/${login}/plugins > wakatime > querying api`);
-    const {data: { data: stats }} = await imports.axios.get(
-      `${wakapi !== false ? apiurl : "http://wakatime.com"}/api/v1/users/${user}/stats/${range}?api_key=${token}`
-    );
+    const {data: { data: stats }} = await imports.axios.get(`${apiurl}/api/v1/users/${user}/stats/${range}?api_key=${token}`);
     const result = {
       sections,
       days,

--- a/source/plugins/wakatime/index.mjs
+++ b/source/plugins/wakatime/index.mjs
@@ -1,44 +1,56 @@
 //Setup
-  export default async function({login, q, imports, data, account}, {enabled = false, token} = {}) {
-    //Plugin execution
-      try {
-        //Check if plugin is enabled and requirements are met
-          if ((!enabled)||(!q.wakatime))
-            return null
+export default async function ({ login, q, imports, data, account },{ enabled = false, token } = {}) {
+  //Plugin execution
+  try {
+    //Check if plugin is enabled and requirements are met
+    if (!enabled || !q.wakatime) return null;
 
-        //Load inputs
-          let {sections, days, limit} = imports.metadata.plugins.wakatime.inputs({data, account, q})
-          if (!limit)
-            limit = void(limit)
-          const range = {"7":"last_7_days", "30":"last_30_days", "180":"last_6_months", "365":"last_year"}[days] ?? "last_7_days"
+    //Load inputs
+    let {
+      sections,
+      days,
+      limit,
+      apiurl,
+      wakapi = false,
+      user = "current",
+    } = imports.metadata.plugins.wakatime.inputs({ data, account, q });
+    if (!limit) limit = void limit;
+    const range =
+      {
+        7: "last_7_days",
+        30: "last_30_days",
+        180: "last_6_months",
+        365: "last_year",
+      }[days] ?? "last_7_days";
 
-        //Querying api and format result (https://wakatime.com/developers#stats)
-          console.debug(`metrics/compute/${login}/plugins > wakatime > querying api`)
-          const {data:{data:stats}} = await imports.axios.get(`https://wakatime.com/api/v1/users/current/stats/${range}?api_key=${token}`)
-          const result = {
-            sections,
-            days,
-            time:{
-              total:stats.total_seconds/(60*60),
-              daily:stats.daily_average/(60*60),
-            },
-            projects:stats.projects.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
-            languages:stats.languages.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
-            os:stats.operating_systems.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
-            editors:stats.editors.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
-          }
+    //Querying api and format result (https://wakatime.com/developers#stats)
+    console.debug(`metrics/compute/${login}/plugins > wakatime > querying api`);
+    const {data: { data: stats }} = await imports.axios.get(
+      `${wakapi !== false ? apiurl : "http://wakatime.com"}/api/v1/users/${user}/stats/${range}?api_key=${token}`
+    );
+    const result = {
+      sections,
+      days,
+      time: {
+        total: stats.total_seconds / (60 * 60),
+        daily: stats.daily_average / (60 * 60),
+      },
+      projects:stats.projects.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
+      languages:stats.languages.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
+      os:stats.operating_systems.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
+      editors:stats.editors.map(({name, percent, total_seconds:total}) => ({name, percent:percent/100, total})).sort((a, b) => b.percent - a.percent).slice(0, limit),
+    };
 
-        //Result
-          return result
-      }
+    //Result
+    return result;
+  } catch (error) {
     //Handle errors
-      catch (error) {
-        let message = "An error occured"
-        if (error.isAxiosError) {
-          const status = error.response?.status
-          message = `API returned ${status}`
-          error = error.response?.data ?? null
-        }
-        throw {error:{message, instance:error}}
-      }
+    let message = "An error occured";
+    if (error.isAxiosError) {
+      const status = error.response?.status;
+      message = `API returned ${status}`;
+      error = error.response?.data ?? null;
+    }
+    throw {error:{message, instance:error }};
   }
+}

--- a/source/plugins/wakatime/metadata.yml
+++ b/source/plugins/wakatime/metadata.yml
@@ -5,7 +5,6 @@ index: 7
 supports:
   - user
 inputs:
-
   # Enable or disable plugin
   plugin_wakatime:
     description: Display WakaTime stats
@@ -24,8 +23,8 @@ inputs:
     description: WakaTime time range
     type: string
     values:
-      - 7   # Last week
-      - 30  # Last month
+      - 7 # Last week
+      - 30 # Last month
       - 180 # Last 6 months
       - 365 # Last year
     default: 7
@@ -35,15 +34,15 @@ inputs:
     description: Sections to display
     type: array
     values:
-      - time             # Show total coding time and daily average
-      - projects         # Show most time spent project
-      - projects-graphs  # Show most time spent projects graphs
-      - languages        # Show most language
+      - time # Show total coding time and daily average
+      - projects # Show most time spent project
+      - projects-graphs # Show most time spent projects graphs
+      - languages # Show most language
       - languages-graphs # Show languages graphs
-      - editors          # Show most used code editor
-      - editors-graphs   # Show code editors graphs
-      - os               # Show most used operating system
-      - os-graphs        # Show code operating systems graphs
+      - editors # Show most used code editor
+      - editors-graphs # Show code editors graphs
+      - os # Show most used operating system
+      - os-graphs # Show code operating systems graphs
     default: time, projects, projects-graphs, languages, languages-graphs, editors, os
 
   # Number of entries to display per graph
@@ -53,3 +52,18 @@ inputs:
     type: number
     default: 5
     min: 0
+
+  plugin_wakatime_wakapi:
+    description: Use WakaTime or self hosted Wakapi instance
+    type: boolean
+    default: no
+
+  plugin_wakatime_apiurl:
+    description: Address where to reach your Wakapi instance
+    type: string
+    default: ""
+
+  plugin_wakatime_user:
+    description: Your Wakatime user on the selfhosted Wakapi instance
+    type: string
+    default: ""

--- a/source/plugins/wakatime/metadata.yml
+++ b/source/plugins/wakatime/metadata.yml
@@ -23,10 +23,10 @@ inputs:
     description: WakaTime time range
     type: string
     values:
-      - 7 # Last week
-      - 30 # Last month
-      - 180 # Last 6 months
-      - 365 # Last year
+      - 7     # Last week
+      - 30    # Last month
+      - 180   # Last 6 months
+      - 365   # Last year
     default: 7
 
   # Sections to display
@@ -34,15 +34,15 @@ inputs:
     description: Sections to display
     type: array
     values:
-      - time # Show total coding time and daily average
-      - projects # Show most time spent project
-      - projects-graphs # Show most time spent projects graphs
-      - languages # Show most language
-      - languages-graphs # Show languages graphs
-      - editors # Show most used code editor
-      - editors-graphs # Show code editors graphs
-      - os # Show most used operating system
-      - os-graphs # Show code operating systems graphs
+      - time              # Show total coding time and daily average
+      - projects          # Show most time spent project
+      - projects-graphs   # Show most time spent projects graphs
+      - languages         # Show most language
+      - languages-graphs  # Show languages graphs
+      - editors           # Show most used code editor
+      - editors-graphs    # Show code editors graphs
+      - os                # Show most used operating system
+      - os-graphs         # Show code operating systems graphs
     default: time, projects, projects-graphs, languages, languages-graphs, editors, os
 
   # Number of entries to display per graph
@@ -53,11 +53,15 @@ inputs:
     default: 5
     min: 0
 
+  # If you use a selfhosted wakatime instance
+  # that is publicly available set this to true
   plugin_wakatime_wakapi:
     description: Use WakaTime or self hosted Wakapi instance
     type: boolean
     default: no
 
+  # If you use the public wakapi instance the url 
+  # would be https://wakapi.dev
   plugin_wakatime_apiurl:
     description: Address where to reach your Wakapi instance
     type: string

--- a/source/plugins/wakatime/metadata.yml
+++ b/source/plugins/wakatime/metadata.yml
@@ -53,21 +53,17 @@ inputs:
     default: 5
     min: 0
 
-  # If you use a selfhosted wakatime instance
-  # that is publicly available set this to true
-  plugin_wakatime_wakapi:
-    description: Use WakaTime or self hosted Wakapi instance
-    type: boolean
-    default: no
-
+  # If you use a selfhosted wakatime instance (wakapi)
+  # that is publicly available place your url here
+  #
   # If you use the public wakapi instance the url 
   # would be https://wakapi.dev
-  plugin_wakatime_apiurl:
-    description: Address where to reach your Wakapi instance
+  plugin_wakatime_url:
+    description: Address where to reach your Wakatime instance
     type: string
-    default: ""
+    default: http://wakatime.com
 
   plugin_wakatime_user:
     description: Your Wakatime user on the selfhosted Wakapi instance
     type: string
-    default: ""
+    default: .user.login


### PR DESCRIPTION
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Add correct labeling
    - Provide a clear and concise description

-->

This PR adds the option to use a selfhosted wakatime instance for the wakatime plugin. 

I tested it against this project called [Wakapi](https://github.com/muety/wakapi) which mimics the same endpoints as wakatime does, so its just a matter of using a different api url