### PR TITLE
Release v3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 Generate your metrics that you can embed everywhere, including your GitHub profile readme! It works for both user and organization accounts, and even for repositories!
 
 
-> <sup>*⚠️ This is the documentation of **v3.10-beta** (`@master` branch) which includes [unreleased features](https://github.com/lowlighter/metrics/compare/latest...master), see documentation of [**v3.9** (`@latest` branch) here](https://github.com/lowlighter/metrics/blob/latest/README.md).*</sup>
-
 
 <table>
   <tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.10.0-beta",
+  "version": "3.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.10.0-beta",
+      "version": "3.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.10.0-beta",
+  "version": "3.10.0",
   "description": "An infographics generator with 30+ plugins and 100+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {

--- a/source/app/metrics/metadata.mjs
+++ b/source/app/metrics/metadata.mjs
@@ -133,7 +133,7 @@ metadata.plugin = async function({__plugins, name, logger}) {
                   }
                   const separators = {"comma-separated":",", "space-separated":" "}
                   const separator = separators[[format].flat().filter(s => s in separators)[0]] ?? ","
-                  return value.split(separator).map(v => replacer(v.trim().toLocaleLowerCase())).filter(v => Array.isArray(values) ? values.includes(v) : true).filter(v => v)
+                  return value.split(separator).map(v => replacer(v.trim()).toLocaleLowerCase()).filter(v => Array.isArray(values) ? values.includes(v) : true).filter(v => v)
                 }
                 //String
                 case "string": {


### PR DESCRIPTION
## 📦 New features

* ↔️ **Introducing larger display size** <sup>✨ new!</sup>
  * #310 You can now choose between `regular` (default) or `large` renders through `config_display` option
  * #310 Plugins may render differently depending on size chosen
    * *It is advised to keep `regular` size if you want metrics to be displayed well both on mobile and desktop (as on mobile it may be rescaled down when displayed)*
  * <img src="https://user-images.githubusercontent.com/22963968/118713145-e3c98b00-b821-11eb-8744-db98cfdd291f.png" width="600">
* 🈷️ **Most used languages**
  * #325 Add `plugin_languages_indepth` option to perform in-depth analysis of your languages statistics
    * *This will clone your repositories, run [github/linguist](https://github.com/github/linguist) on them and iterate through matching `git log` entries. See [plugins/languages/README.md](https://github.com/lowlighter/metrics/blob/master/source/plugins/languages/README.md#using-indepth-statistics) before enabling*
    * Use [`commits_authoring`](https://github.com/lowlighter/metrics/blob/master/source/plugins/languages/README.md#commits_authoring-option) for better results
    * b0d37f3 Use `npm run indepth` to launch this tool locally on a given repository
  * #327 Add `plugin_languages_sections` and new "Recently used" section
    * <img src="https://user-images.githubusercontent.com/22963968/119811663-a29f3e00-bee7-11eb-883f-645c5e4f5d34.png" width="400">
    * Use `plugin_languages_recent_load` and `plugin_languages_recent_days` to customize how many events will be loaded and which time window should be used
  *  #329 Add `lines` to `plugin_languages_details` to display an estimate of number of lines of code written (requires `plugin_languages_indepth` to be enabled)
* 🎩 **Notable contributions**
  * #293 Contributions are now sorted by most starred
* 📰 **Recent activity**
  * 2b9d8e8 Add `plugin_activity_load` to support a custom number of activity events to load
* 🎟️ **Follow-up of issues and pull requests** 
  * #310 Repository template now displays closed pull requests like classic template
* 💡 **Coding habits**
  * fb745b4 Average characters per line of code is now displayed
  * #337 Texts improvements  
  * dc271db Some changes in recent languages activity graph has been made to reflect `languages` plugin changes
* 🧑‍🤝‍🧑 **People plugin** 
  * d2d5762 Default value for `plugin_people_limit` has been from 28 to lowered 24
* 🌐 **Web instances**
  * #299 Add copy button to action tab
  * <img src="https://user-images.githubusercontent.com/22963968/118328533-4828d980-b506-11eb-861e-bba541ca9837.png" width="600">
* 🦑 **Miscelleanous**
  * aabb21f You can now use `@main` branch instead of `@master`  branch
  * 6b129ab Text "forks" was changed to "forkers" in repositories base section to avoid confusion
  * 6b37fe4 `dependabot-preview[bot]` is now ignored by default
  * #308 `config_padding` now accepts absolute values
    * Default value has been changed for better SVG heights, you may need to re-adjust this option if you were using it 
  * #326 Use config timezone in all displayed times 
  * #336 Timezone metadata has been moved next to generated timestamp for better readability
## 🧰 Fixes
* 421a770 📰 Fix error when a push event has 0 commits  
* 75978e8 📰 Fix forked repositories where target repository wasn't displayed
* #310 📰 Fix repository template display issues
* #310 🏅 Fix an issue where unknown commits author were crashing the plugin
* #310 📜 Fix an issue where licensed was returning an empty result which made the plugin crash
* dca7f76 🗃️ Fix affiliations constraint where authenticated user wasn't the target user
* #307 🗃️ Generated date now use defined timezone instead of GMT+0
* d25b286 🧱 Fix `config_padding` which was not handling well percentage values and was actually useless
* #347 🗨️ Fix an issue where comments count were marked as undefined
* #346 ✨ Fix a clipping issue on mobile

## 👏 Achievements

Reached [4+ millions downloads](https://github.com/users/lowlighter/packages/container/package/metrics), [3 000+ stargazers](https://github.com/lowlighter/metrics/stargazers) and [1 000+ commits](https://github.com/lowlighter/metrics/commits/master)!
Thanks for your support 🎉 !

## 💕 Sponsors and contributors
<img src="https://raw.githubusercontent.com/lowlighter/lowlighter/master/metrics.sponsors.svg">
<img src="https://raw.githubusercontent.com/lowlighter/lowlighter/master/metrics.contributors.svg">

[`♥️ Become a sponsor`](https://github.com/sponsors/lowlighter)