### PR TITLE
Use config timezone in all displayed times

### DIFF
--- a/source/app/web/statics/about/index.html
+++ b/source/app/web/statics/about/index.html
@@ -251,7 +251,7 @@
               </h2>
               <ul v-if="activity.length">
                 <li v-for="{actor, type, repo, timestamp, ...event} of activity">
-                  <time :datetime="timestamp">{{ format("date", timestamp, {timeStyle:"short", dateStyle:"short"}) }}</time>
+                  <time :datetime="timestamp">{{ format("date", timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name}) }}</time>
                   <div class="actor" v-if="account.type === 'organization'">
                     <img :src="`https://github.com/${/\[bot\]$/.test(actor) ? 'actions' : actor }.png`">
                     <a :href="`https://github.com/${actor}`">{{ actor }}</a>

--- a/source/templates/classic/partials/activity.ejs
+++ b/source/templates/classic/partials/activity.ejs
@@ -163,7 +163,7 @@
                 <% } %>
                 <% if (plugins.activity.timestamps) { %>
                   <div class="timestamp">
-                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name ?? "UTC"}) %>
+                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name}) %>
                   </div>
                 <% } %>
               </section>

--- a/source/templates/classic/partials/activity.ejs
+++ b/source/templates/classic/partials/activity.ejs
@@ -163,7 +163,7 @@
                 <% } %>
                 <% if (plugins.activity.timestamps) { %>
                   <div class="timestamp">
-                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short"}) %>
+                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name ?? "UTC"}) %>
                   </div>
                 <% } %>
               </section>

--- a/source/templates/classic/partials/posts.ejs
+++ b/source/templates/classic/partials/posts.ejs
@@ -23,7 +23,7 @@
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M4.75 0a.75.75 0 01.75.75V2h5V.75a.75.75 0 011.5 0V2h1.25c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V3.75C1 2.784 1.784 2 2.75 2H4V.75A.75.75 0 014.75 0zm0 3.5h8.5a.25.25 0 01.25.25V6h-11V3.75a.25.25 0 01.25-.25h2zm-2.25 4v6.75c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V7.5h-11z"></path></svg>
                   <div class="infos">
                     <div class="left">
-                      <div class="date"><%= f.date(new Date(date), {dateStyle:"short"}) %></div>
+                      <div class="date"><%= f.date(new Date(date), {dateStyle:"short", timeZone:config.timezone?.name}) %></div>
                       <% if (plugins.posts.covers) { %>
                         <div class="cover" style="background-image: url(<%= image %>);"></div>
                       <% } %>

--- a/source/templates/classic/partials/rss.ejs
+++ b/source/templates/classic/partials/rss.ejs
@@ -18,7 +18,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8 5.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM4 8a4 4 0 118 0 4 4 0 01-8 0z"></path></svg>
                 <div class="infos">
                   <div class="title"><%= title %></div>
-                  <div class="date"><%= f.date(new Date(date), {dateStyle:"short"}) %></div>
+                  <div class="date"><%= f.date(new Date(date), {dateStyle:"short", timeZone:config.timezone?.name}) %></div>
                 </div>
               </div>
             <% } %>

--- a/source/templates/markdown/partials/activity.ejs
+++ b/source/templates/markdown/partials/activity.ejs
@@ -39,7 +39,7 @@
 * 🚮 Deleted <%= event.ref.type %> `<%= event.ref.name %>` from [<%= repo %>](https://github.com/<%= repo %>)
       <%_ } _%>
       <%_ if (plugins.activity.timestamps) { _%>
-  * *On <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short"}) %>*
+  * *On <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name}) %>*
       <%_ } _%>
     <%_ } _%>
   <%_ } else { _%>

--- a/source/templates/markdown/partials/posts.ejs
+++ b/source/templates/markdown/partials/posts.ejs
@@ -19,7 +19,7 @@
     <td>
       <%= description %>
       <br>
-      <i>Published on <%= f.date(new Date(date), {dateStyle:"short"}) %></i>
+      <i>Published on <%= f.date(new Date(date), {dateStyle:"short", timeZone:config.timezone?.name}) %></i>
     </td>
   </tr>
 </table>
@@ -27,7 +27,7 @@
   <%_ } else if (plugins.posts.list.length) { _%>
     <%_ for (const {title, date, link} of plugins.posts.list) { _%>
 * [<%= title.trim() %>](<%= link %>)
-  * *Published on <%= f.date(new Date(date), {dateStyle:"short"}) %>*
+  * *Published on <%= f.date(new Date(date), {dateStyle:"short", timeZone:config.timezone?.name}) %>*
     <%_ } _%>
   <%_ } else { _%>
 No recent posts

--- a/source/templates/repository/partials/activity.ejs
+++ b/source/templates/repository/partials/activity.ejs
@@ -163,7 +163,7 @@
                 <% } %>
                 <% if (plugins.activity.timestamps) { %>
                   <div class="timestamp">
-                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short"}) %>
+                    <%= f.date(timestamp, {timeStyle:"short", dateStyle:"short", timeZone:config.timezone?.name}) %>
                   </div>
                 <% } %>
               </section>

--- a/source/templates/repository/partials/rss.ejs
+++ b/source/templates/repository/partials/rss.ejs
@@ -18,7 +18,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8 5.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM4 8a4 4 0 118 0 4 4 0 01-8 0z"></path></svg>
                 <div class="infos">
                   <div class="title"><%= title %></div>
-                  <div class="date"><%= f.date(new Date(date), {dateStyle:"short"}) %></div>
+                  <div class="date"><%= f.date(new Date(date), {dateStyle:"short", timeZone:config.timezone?.name}) %></div>
                 </div>
               </div>
             <% } %>


### PR DESCRIPTION
Adds timeZone argument to the date constructor in the recent activity plugin to add a timezone to the times. Should make it so that the times all display in the user's set timezone.
Haven't tested it though.
Fixes #324.