### PR TITLE
Add margin to insights rankeds to avoid clipping

### DIFF
--- a/source/app/web/statics/about/style.css
+++ b/source/app/web/statics/about/style.css
@@ -230,6 +230,7 @@
 
 /* Ranked achievements */
   .rankeds {
+    margin-top: 2em;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
The icons use `scale:transform(1.75)` which makes them exit their containers and clip into the text on mobile.

Adds a 2em margin to `.rankeds` to avoid this clipping.

#342.