### PR TITLE
Initialise StackOverflow comment count as 0

### DIFF
--- a/source/plugins/stackoverflow/index.mjs
+++ b/source/plugins/stackoverflow/index.mjs
@@ -112,7 +112,7 @@ const format = {
       tags,
       is_answered:answered,
       answer_count:answers,
-      comment_count:comments,
+      comment_count:comments = 0,
       view_count:views,
       creation_date,
       owner:{display_name:author},


### PR DESCRIPTION
lowlighter in #344:

> Indeed, seems that anwser formatter has `comment_count:comments = 0` to handle this bug, but the question formatter has no default:
> https://github.com/lowlighter/metrics/blob/2ae690fac73120264a7221f821e0e708c11f3fc4/source/plugins/stackoverflow/index.mjs#L115
> 
> It would just need to append a `= 0` to default it when api doesn't return this field

This PR does so