### PR TITLE
Improve apt process in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,22 +15,20 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get update \
   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 --no-install-recommends \
   && apt-get install -y ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils \
-  && rm -rf /var/lib/apt/lists/* \
   # Install ruby to support github gems
   # Based on https://github.com/github/linguist and https://github.com/github/licensed
-  && apt-get update \
   && apt-get install -y ruby-full \
   && apt-get install -y git g++ cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev \
   && gem install github-linguist \
   && gem install licensed \
   # Install python for node-gyp
-  && apt-get update \
   && apt-get install -y python3 \
   # Install node modules
   && cd /metrics \
   && npm ci \
   # Rebuild indexes
-  && npm run index
+  && npm run index \
+  && rm -rf /var/lib/apt/lists/*
 
 # Environment variables
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true


### PR DESCRIPTION
Not sure which type of contribution this one should be as it doesn't seem to meet the criteria here: https://github.com/lowlighter/metrics/blob/1a5295115767cd5c7e15b6546399ff9fef377ba6/CONTRIBUTING.md#-accepted-contributions

This pull request will help speed up the Docker image build process, and also, make the built image smaller, by remove additional `apt-get update` and put the clean up process the end, which is the proper place for it.

Feel free to let me know if there is anything more I should do, thanks!