### PR TITLE
Compute processed files/commits from analyzers

### DIFF
--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -38,7 +38,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
 
     //Iterate through user's repositories and retrieve languages data
     console.debug(`metrics/compute/${login}/plugins > languages > processing ${data.user.repositories.nodes.length} repositories`)
-    const languages = {unique, sections, details, colors:{}, total:0, stats:{}, "stats.recent":{}}
+    const languages = {unique, sections, details, indepth, colors:{}, total:0, stats:{}, "stats.recent":{}}
     for (const repository of data.user.repositories.nodes) {
       //Skip repository if asked
       if ((skipped.includes(repository.name.toLocaleLowerCase())) || (skipped.includes(`${repository.owner.login}/${repository.name}`.toLocaleLowerCase()))) {
@@ -63,6 +63,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
     if (indepth) {
       console.debug(`metrics/compute/${login}/plugins > languages > switching to indepth mode (this may take some time)`)
       Object.assign(languages, await indepth_analyzer({login, data, imports, repositories}, {skipped}))
+      console.log(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed} commits`)
     }
 
     //Compute languages stats
@@ -79,7 +80,6 @@ export default async function({login, data, imports, q, rest, account}, {enabled
       }
     }
 
-console.log(aliases)
     //Apply aliases
     for (const section of ["favorites", "recent"]) {
       for (const language of languages[section]) {

--- a/source/templates/classic/partials/languages.ejs
+++ b/source/templates/classic/partials/languages.ejs
@@ -22,6 +22,10 @@
           <small>
             estimation from <%= plugins.languages["stats.recent"]?.files %> edited file<%= s(plugins.languages["stats.recent"]?.files) %> from <%= plugins.languages["stats.recent"]?.commits %> commit<%= s(plugins.languages["stats.recent"]?.commits) %> over last <%= plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days %> day<%= s(plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days) %>
           </small>
+        <% } else if ((section === "most-used")&&(plugins.languages.indepth)) { %>
+          <small>
+            estimation from <%= plugins.languages.files %> edited file<%= s(plugins.languages.files) %> from <%= plugins.languages.commits %> commit<%= s(plugins.languages.commits) %>
+          </small>
         <% } %>
         <svg class="bar" xmlns="http://www.w3.org/2000/svg" width="<%= width %>" height="8">
           <mask id="languages-bar">


### PR DESCRIPTION
This tweak a bit the analyzers to achieve the following:

- Edited files are now computed on the fly using a `Set`
  - Most used section will now be able to display how many files you edited
  - Recently used section will "de-duplicate" files that were edited multiples times across different push events
- Commits are now computed on the fly
  - Most used section will now be able to display how many commits were processed
    - Missed commits (i.e. the ones that failed for any reason will also be counted and displayed for reporting in action logs)
  - Recently used section still base itself on push events retrieved   