### PR TITLE
Web instances: Add flags to enable unsafe extra features

### DIFF
--- a/source/app/web/settings.example.json
+++ b/source/app/web/settings.example.json
@@ -27,7 +27,8 @@
   },
   "extras": {
     "default": false,              "//": "Default extras state (advised to let 'false' unless in debug mode)",
-    "css": false,                  "//": "Allow use of 'extras.css' option"
+    "css": false,                  "//": "Allow use of 'extras.css' option",
+    "features": false,             "//": "Enable extra features (advised to let 'false' on web instances)"
   },
   "plugins.default": false,        "//": "Default plugin state (advised to let 'false' unless in debug mode)",
   "plugins": {                     "//": "Global plugin configuration",

--- a/source/plugins/core/index.mjs
+++ b/source/plugins/core/index.mjs
@@ -47,7 +47,7 @@ export default async function({login, q}, {conf, data, rest, graphql, plugins, q
     pending.push((async () => {
       try {
         console.debug(`metrics/compute/${login}/plugins > ${name} > started`)
-        data.plugins[name] = await imports.plugins[name]({login, q, imports, data, computed, rest, graphql, queries, account}, plugins[name])
+        data.plugins[name] = await imports.plugins[name]({login, q, imports, data, computed, rest, graphql, queries, account}, {...plugins[name], extras:conf.settings?.extras?.features ?? conf.settings?.extras?.default ?? false})
         console.debug(`metrics/compute/${login}/plugins > ${name} > completed`)
       }
       catch (error) {

--- a/source/plugins/habits/README.md
+++ b/source/plugins/habits/README.md
@@ -21,6 +21,8 @@ Use a full `repo` scope token to access **private** events.
 
 By default, dates use Greenwich meridian (GMT/UTC). Be sure to set your timezone (see [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of supported timezones) for accurate metrics.
 
+> 🔣 On web instances, *recent languages activity* is an extra feature and must be enabled globally in `settings.json`
+
 #### ℹ️ Examples workflows
 
 [➡️ Available options for this plugin](metadata.yml)

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -2,7 +2,7 @@
 import { recent as recent_analyzer } from "./../languages/analyzers.mjs"
 
 //Setup
-export default async function({login, data, rest, imports, q, account}, {enabled = false, ...defaults} = {}) {
+export default async function({login, data, rest, imports, q, account}, {enabled = false, extras = false, ...defaults} = {}) {
   //Plugin execution
   try {
     //Check if plugin is enabled and requirements are met
@@ -97,7 +97,7 @@ export default async function({login, data, rest, imports, q, account}, {enabled
     }
 
     //Linguist
-    if (charts) {
+    if ((extras)&&(charts)) {
       //Check if linguist exists
       console.debug(`metrics/compute/${login}/plugins > habits > searching recently used languages using linguist`)
       if (patches.length) {
@@ -109,7 +109,6 @@ export default async function({login, data, rest, imports, q, account}, {enabled
       }
       else
         console.debug(`metrics/compute/${login}/plugins > habits > linguist not available`)
-
     }
 
     //Results

--- a/source/plugins/languages/README.md
+++ b/source/plugins/languages/README.md
@@ -30,8 +30,10 @@ If you work a lot with other people, these numbers may be less representative of
 
 The `plugin_languages_indepth` option lets you get more accurate metrics by cloning each repository you contributed to, running [github/linguist](https://github.com/github/linguist) on it and then iterating over patches matching your username from `git log`. This method is slower than the first one.
 
-> ⚠️ Although *metrics* does not send any code to external sources, you must understand that when using this option repositories are cloned locally temporarly on the GitHub Action runner. If you work with sensitive data or company code, it is advised to keep this option disabled. *Metrics* cannot be held responsible for any eventual code leaks, use at your own risk.
+> ⚠️ Although *metrics* does not send any code to external sources, you must understand that when using this option repositories are cloned locally temporarly on the GitHub Action runner. If you work with sensitive data or company code, it is advised to keep this option disabled. *Metrics* and its authors cannot be held responsible for any eventual code leaks, use at your own risk.
 > Source code is available for auditing at [analyzers.mjs](/source/plugins/languages/analyzers.mjs)
+
+> 🔣 On web instances, `indepth` is an extra feature and must be enabled globally in `settings.json`
 
 #### `commits_authoring` option
 

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -2,7 +2,7 @@
 import { indepth as indepth_analyzer, recent as recent_analyzer } from "./analyzers.mjs"
 
 //Setup
-export default async function({login, data, imports, q, rest, account}, {enabled = false} = {}) {
+export default async function({login, data, imports, q, rest, account}, {enabled = false, extras = false} = {}) {
   //Plugin execution
   try {
     //Check if plugin is enabled and requirements are met
@@ -52,17 +52,20 @@ export default async function({login, data, imports, q, rest, account}, {enabled
       }
     }
 
-    //Recently used languages
-    if ((sections.includes("recently-used"))&&(context.mode === "user")) {
-      console.debug(`metrics/compute/${login}/plugins > languages > using recent analyzer`)
-      languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, days:_recent_days, load:_recent_load})
-    }
+    //Extras features
+    if (extras) {
+      //Recently used languages
+      if ((sections.includes("recently-used"))&&(context.mode === "user")) {
+        console.debug(`metrics/compute/${login}/plugins > languages > using recent analyzer`)
+        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, days:_recent_days, load:_recent_load})
+      }
 
-    //Indepth mode
-    if (indepth) {
-      console.debug(`metrics/compute/${login}/plugins > languages > switching to indepth mode (this may take some time)`)
-      Object.assign(languages, await indepth_analyzer({login, data, imports, repositories}, {skipped}))
-      console.debug(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed} commits`)
+      //Indepth mode
+      if (indepth) {
+        console.debug(`metrics/compute/${login}/plugins > languages > switching to indepth mode (this may take some time)`)
+        Object.assign(languages, await indepth_analyzer({login, data, imports, repositories}, {skipped}))
+        console.debug(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed} commits`)
+      }
     }
 
     //Compute languages stats

--- a/source/plugins/licenses/README.md
+++ b/source/plugins/licenses/README.md
@@ -1,8 +1,10 @@
 ### 📜 Repository licenses
 
 > ⚠️ This is **NOT** legal advice, use at your own risk
->
-> 💣 Do **NOT** enable this plugin on public web instances (plugin allows raw commands injection)
+
+> 🔣 On web instances, this plugin is an extra feature and must be enabled globally in `settings.json`
+> 💣 Note that this plugin allows raw commands injection and is **NOT** advised to be enabled on them
+> This could result in compromised server!
 
 The *licenses* plugin lets you display license informations like permissions, limitations and conditions along with additional metrics about dependencies.
 

--- a/source/plugins/licenses/index.mjs
+++ b/source/plugins/licenses/index.mjs
@@ -1,9 +1,9 @@
 //Setup
-export default async function({login, q, imports, data, graphql, queries, account}, {enabled = false} = {}) {
+export default async function({login, q, imports, data, graphql, queries, account}, {enabled = false, extras = false} = {}) {
   //Plugin execution
   try {
     //Check if plugin is enabled and requirements are met
-    if ((!enabled) || (!q.licenses))
+    if ((!enabled) || (!extras) || (!q.licenses))
       return null
 
     //Load inputs


### PR DESCRIPTION
Because some plugins have extra features that requires to perform modifications on the host (like downloading files, child process, remote code executions, etc), these are not suited for web instances.

This add a flags to let hosters toggle extra features