### PR TITLE
Sort discussion categories for display

### DIFF
--- a/source/plugins/discussions/index.mjs
+++ b/source/plugins/discussions/index.mjs
@@ -32,9 +32,9 @@
           //Compute favorite category
           for (const category of [...fetched.map(({category:{emoji, name}}) => `${imports.emoji.get(emoji)} ${name}`)])
             categories[category] = (categories[category] ?? 0) + 1
-          let categoryEntries = Object.entries(categories).sort((a, b) => b[1] - a[1])
+          const categoryEntries = Object.entries(categories).sort((a, b) => b[1] - a[1])
           discussions.categories.stats = Object.fromEntries(categoryEntries)
-          discussions.categories.favorite = categories[0]?.[0] ?? null
+          discussions.categories.favorite = categoryEntries[0]?.[0] ?? null
         }
 
         //Results

--- a/source/plugins/discussions/index.mjs
+++ b/source/plugins/discussions/index.mjs
@@ -32,8 +32,9 @@
           //Compute favorite category
           for (const category of [...fetched.map(({category:{emoji, name}}) => `${imports.emoji.get(emoji)} ${name}`)])
             categories[category] = (categories[category] ?? 0) + 1
-          discussions.categories.stats = categories
-          discussions.categories.favorite = Object.entries(categories).sort((a, b) => b[1] - a[1]).map(([name]) => name).shift() ?? null
+          let categoryEntries = Object.entries(categories).sort((a, b) => b[1] - a[1])
+          discussions.categories.stats = Object.fromEntries(categoryEntries)
+          discussions.categories.favorite = categories[0]?.[0] ?? null
         }
 
         //Results


### PR DESCRIPTION
Discussions are currently displayed unsorted; this change sorts them by amount before being displayed.

#### Before
![image](https://user-images.githubusercontent.com/42429413/128593998-b4966d74-c3ab-479a-ad65-6c78926dea57.png)
#### After
![image](https://user-images.githubusercontent.com/42429413/128593951-66966a83-fa60-4d58-a244-8b8627d124a2.png)
