### PR TITLE
Use display name instead of username in followup plugin

### DIFF
--- a/source/templates/classic/partials/followup.ejs
+++ b/source/templates/classic/partials/followup.ejs
@@ -16,7 +16,7 @@
     <% for (const name of plugins.followup.sections) { const section = {repositories:plugins.followup, user:plugins.followup?.user}[name] %>
       <div class="column largeable">
         <h3>
-          <%= {repositories:`On ${user.login}'${[...user.login].pop() === "s" ? "" : "s"} repositories`, user:`Created by ${user.login}`}[name] %>
+          <%= {repositories:`On ${user.name ?? user.login}'s repositories`, user:`Created by ${user.name ?? user.login}`}[name] %>
         </h3>
         <div class="row fill-width">
           <section class="column">


### PR DESCRIPTION
- Resolve #460

## Description
Changes the name listed in the followup headers to priorities display name with a fallback to username as [query]`.name` is nullable.

Also removes the ends-with-s check as "Names's" isn't incorrect.

*Sidenote,  `[...string].pop() === x` is quite an overcomplicated way of doing `string.endsWith(x)`.*