### PR TITLE
Repository: add number action users statistic

### DIFF
--- a/source/templates/repository/partials/base.header.ejs
+++ b/source/templates/repository/partials/base.header.ejs
@@ -48,6 +48,12 @@
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75zM7.25 8a.75.75 0 01-.22.53l-2.25 2.25a.75.75 0 11-1.06-1.06L5.44 8 3.72 6.28a.75.75 0 111.06-1.06l2.25 2.25c.141.14.22.331.22.53zm1.5 1.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z"></path></svg>
           <%= repo.environments.totalCount %> Environment<%= s(repo.environments.totalCount) %>
         </div>
+        <% if (repo.actionUsersCount) { %>
+          <div class="field">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zM6.379 5.227A.25.25 0 006 5.442v5.117a.25.25 0 00.379.214l4.264-2.559a.25.25 0 000-.428L6.379 5.227z"></path></svg>
+            <%= repo.actionUsersCount %> workflow<%= s(repo.actionUsersCount) %> using it
+          </div>
+        <% } %>
         <% if (plugins.lines) { %>
             <div class="field <%= plugins.lines.error ? 'error' : '' %>">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V4.664a.25.25 0 00-.073-.177l-2.914-2.914a.25.25 0 00-.177-.073H2.75zM1 1.75C1 .784 1.784 0 2.75 0h7.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V1.75zm7 1.5a.75.75 0 01.75.75v1.5h1.5a.75.75 0 010 1.5h-1.5v1.5a.75.75 0 01-1.5 0V7h-1.5a.75.75 0 010-1.5h1.5V4A.75.75 0 018 3.25zm-3 8a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5h-4.5a.75.75 0 01-.75-.75z"></path></svg>

--- a/source/templates/repository/template.mjs
+++ b/source/templates/repository/template.mjs
@@ -63,6 +63,18 @@ export default async function({login, q}, {data, rest, graphql, queries, account
   //Override plugins parameters
   q["projects.limit"] = 0
 
+  //Fetching users count if it's an action
+  try {
+    if (await rest.repos.getContent({owner:login, repo, path:"action.yml"})) {
+      console.debug(`metrics/compute/${login}/${repo} > this repository seems to be a GitHub action, fetching users using code search`)
+      const {data:{total_count}} = await rest.search.code({q:`uses ${login} ${repo} path:.github/workflows language:YAML`})
+      data.repo.actionUsersCount = total_count
+    }
+  }
+  catch {
+    //Ignore errors
+  }
+
   //Core
   await imports.plugins.core(...arguments)
   await Promise.all(pending)


### PR DESCRIPTION
Repository template now display stats about users (if it's a github action)

![metrics](https://user-images.githubusercontent.com/22963968/129206422-74d08158-e2cd-4ef2-974b-1b71e6867bfa.png)

This is performed by looking if an `action.yml` exists on target repository, and then by using search code for `uses ${login} ${repo} path:.github/workflows language:YAML` and counting results