### PR TITLE
Add options to configure which language categories to display

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -334,6 +334,16 @@ inputs:
     description: Indepth languages processing (see documentation before enabling)
     default: false
   
+  
+  plugin_languages_categories:
+    description: Language categories to display
+    default: markup, programming
+  
+  # GitHub language categories to display in recently-used section
+  plugin_languages_recent_categories:
+    description: Language categories to display (for recently used section)
+    default: markup, programming
+  
   # Number of activity events to load (for recently used languages statistics)
   # A high number will consume more requests
   plugin_languages_recent_load:

--- a/action.yml
+++ b/action.yml
@@ -334,16 +334,6 @@ inputs:
     description: Indepth languages processing (see documentation before enabling)
     default: false
   
-  
-  plugin_languages_categories:
-    description: Language categories to display
-    default: markup, programming
-  
-  # GitHub language categories to display in recently-used section
-  plugin_languages_recent_categories:
-    description: Language categories to display (for recently used section)
-    default: markup, programming
-  
   # Number of activity events to load (for recently used languages statistics)
   # A high number will consume more requests
   plugin_languages_recent_load:

--- a/source/plugins/languages/README.md
+++ b/source/plugins/languages/README.md
@@ -55,10 +55,11 @@ For better results, it's advised to add either your surnames and eventually no-r
     plugin_languages_colors: "0:orange, javascript:#ff0000, ..."  # Make most used languages orange and JavaScript red
     plugin_languages_aliases: "JavaScript:JS, TypeScript:TS, ..." # Customize languages names with aliases
     plugin_languages_details: bytes-size, percentage              # Additionally display total bytes size and percentage
-    plugin_la nguages_threshold: 2%                               # Hides all languages less than 2%
+    plugin_languages_threshold: 2%                                # Hides all languages less than 2%
     plugin_languages_limit: 8                                     # Display up to 8 languages
     plugin_languages_sections: most-used, recently-used           # Display most used and recently used languages stats
     plugin_languages_indepth: no                                  # Get indepth stats (see documentation before enabling)
+    plugin_languages_categories: markup, programming, data        # Display languages that match these categories
     plugin_languages_recent_load: 500                             # Load up to 500 events to compute recently used stats
     plugin_languages_recent_days: 7                               # Limit recently used stats to last week
     commits_authoring: lowlighter@users.noreply.github.com        # Surnames or email addresses used to identify your commits

--- a/source/plugins/languages/README.md
+++ b/source/plugins/languages/README.md
@@ -59,7 +59,8 @@ For better results, it's advised to add either your surnames and eventually no-r
     plugin_languages_limit: 8                                     # Display up to 8 languages
     plugin_languages_sections: most-used, recently-used           # Display most used and recently used languages stats
     plugin_languages_indepth: no                                  # Get indepth stats (see documentation before enabling)
-    plugin_languages_categories: markup, programming, data        # Display languages that match these categories
+    plugin_languages_categories: programming                      # Display only languages that match these categories in most-used section
+    plugin_languages_categories: markup, programming, data        # Display only languages that match these categories in recently-used section
     plugin_languages_recent_load: 500                             # Load up to 500 events to compute recently used stats
     plugin_languages_recent_days: 7                               # Limit recently used stats to last week
     commits_authoring: lowlighter@users.noreply.github.com        # Surnames or email addresses used to identify your commits

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -29,7 +29,7 @@ export async function indepth({login, data, imports, repositories}, {skipped}) {
       await git.clone(`https://github.com/${repo}`, ".").status()
 
       //Analyze repository
-      await analyze(arguments[0], {type:"indepth", results, path})
+      await analyze(arguments[0], {section:"indepth", results, path})
     }
     catch (error) {
       console.debug(`metrics/compute/${login}/plugins > languages > indepth > an error occured while processing ${repo}, skipping...`)
@@ -118,7 +118,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
       await git.init().add(".").addConfig("user.name", data.shared["commits.authoring"]?.[0] ?? login).addConfig("user.email", "<>").commit("linguist").status()
 
       //Analyze repository
-      await analyze(arguments[0], {type:"recent", results, path:imports.paths.join(path, directory)})
+      await analyze(arguments[0], {section:"recent", results, path:imports.paths.join(path, directory)})
 
       //Since we reproduce a "partial repository" with a single commit, use number of commits retrieved instead
       results.commits = commits.length
@@ -136,7 +136,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
 }
 
 /**Analyze a single repository */
-async function analyze({login, imports, data}, {type, results, path}) {
+async function analyze({login, imports, data}, {section, results, path}) {
   //Gather language data
   console.debug(`metrics/compute/${login}/plugins > languages > indepth > running linguist`)
   const {results:files, languages:languageResults} = await linguist(path)
@@ -166,8 +166,7 @@ async function analyze({login, imports, data}, {type, results, path}) {
           if (/^[+]{3}\sb[/](?<file>[\s\S]+)$/.test(line)) {
             file = line.match(/^[+]{3}\sb[/](?<file>[\s\S]+)$/)?.groups?.file.replace(/^/, `${path}/`) ?? null
             lang = files[file] ?? null
-            const ignored = ["data", "markup", "programming", "prose"].map(type => data.shared[type === "recent" ? "recent.categories" : "categories"].includes(type) && lang in languageResults[type]).filter(type => type)
-            if (ignored.length)
+            if (["data", "markup", "programming", "prose"].map(type => data.shared[section === "recent" ? "recent.categories" : "categories"].includes(type) && lang in languageResults[type]).filter(type => type).length)
               lang = null
             edited.add(file)
             return

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -1,7 +1,7 @@
 import linguist from "linguist-js"
 
 /**Indepth analyzer */
-export async function indepth({login, data, imports, repositories}, {skipped}) {
+export async function indepth({login, data, imports, repositories}, {skipped, categories}) {
 
   //Compute repositories stats from fetched repositories
   const results = {total:0, lines:{}, stats:{}, commits:0, files:0, missed:0}
@@ -44,7 +44,7 @@ export async function indepth({login, data, imports, repositories}, {skipped}) {
 }
 
 /**Recent languages activity */
-export async function recent({login, data, imports, rest, account}, {skipped = [], days = 0, load = 0, tempdir = "recent"}) {
+export async function recent({login, data, imports, rest, account}, {skipped = [], categories, days = 0, load = 0, tempdir = "recent"}) {
 
   //Get user recent activity
   console.debug(`metrics/compute/${login}/plugins > languages > querying api`)

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -207,7 +207,8 @@ if (/languages.analyzers.mjs$/.test(process.argv[1])) {
     }
     const {default:setup} = await import("../../app/metrics/setup.mjs")
     const {conf:{metadata}} = await setup({log:false, nosettings:true})
-    const {"commits.authoring":authoring, categories:_categories} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
+    const {"commits.authoring":authoring} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
+    const {categories:_categories} = await metadata.plugins.languages.inputs({q:{}, account:"bypass"})
     const data = {shared:{"commits.authoring":authoring, categories:_categories}}
 
     //Prepare call

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -166,7 +166,7 @@ async function analyze({login, imports, data}, {results, path, categories = ["pr
           if (/^[+]{3}\sb[/](?<file>[\s\S]+)$/.test(line)) {
             file = line.match(/^[+]{3}\sb[/](?<file>[\s\S]+)$/)?.groups?.file.replace(/^/, `${path}/`) ?? null
             lang = files[file] ?? null
-            if (["data", "markup", "programming", "prose"].map(type => categories.includes(type) && lang in languageResults[type]).filter(type => type).length)
+            if (["data", "markup", "programming", "prose"].map(type => categories.includes(type) && lang in languageResults[type]).filter(type => type).length === 0)
               lang = null
             edited.add(file)
             return

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -29,7 +29,7 @@ export async function indepth({login, data, imports, repositories}, {skipped}) {
       await git.clone(`https://github.com/${repo}`, ".").status()
 
       //Analyze repository
-      await analyze(arguments[0], {results, path})
+      await analyze(arguments[0], {type:"indepth", results, path})
     }
     catch (error) {
       console.debug(`metrics/compute/${login}/plugins > languages > indepth > an error occured while processing ${repo}, skipping...`)
@@ -118,7 +118,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
       await git.init().add(".").addConfig("user.name", data.shared["commits.authoring"]?.[0] ?? login).addConfig("user.email", "<>").commit("linguist").status()
 
       //Analyze repository
-      await analyze(arguments[0], {results, path:imports.paths.join(path, directory)})
+      await analyze(arguments[0], {type:"recent", results, path:imports.paths.join(path, directory)})
 
       //Since we reproduce a "partial repository" with a single commit, use number of commits retrieved instead
       results.commits = commits.length
@@ -136,7 +136,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
 }
 
 /**Analyze a single repository */
-async function analyze({login, imports, data}, {results, path}) {
+async function analyze({login, imports, data}, {type, results, path}) {
   //Gather language data
   console.debug(`metrics/compute/${login}/plugins > languages > indepth > running linguist`)
   const {results:files, languages:languageResults} = await linguist(path)
@@ -166,7 +166,7 @@ async function analyze({login, imports, data}, {results, path}) {
           if (/^[+]{3}\sb[/](?<file>[\s\S]+)$/.test(line)) {
             file = line.match(/^[+]{3}\sb[/](?<file>[\s\S]+)$/)?.groups?.file.replace(/^/, `${path}/`) ?? null
             lang = files[file] ?? null
-            const ignored = ["data", "markup", "programming", "prose"].map(type => data.shared.categories.includes(type) && lang in languageResults[type]).filter(type => type)
+            const ignored = ["data", "markup", "programming", "prose"].map(type => data.shared[type === "recent" ? "recent.categories" : "categories"].includes(type) && lang in languageResults[type]).filter(type => type)
             if (ignored.length)
               lang = null
             edited.add(file)

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -136,7 +136,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
 }
 
 /**Analyze a single repository */
-async function analyze({login, imports, data}, {results, path, categories}) {
+async function analyze({login, imports, data}, {results, path, categories = ["programming", "markup"]}) {
   //Gather language data
   console.debug(`metrics/compute/${login}/plugins > languages > indepth > running linguist`)
   const {results:files, languages:languageResults} = await linguist(path)

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -166,12 +166,13 @@ async function analyze({login, imports, data}, {results, path}) {
           if (/^[+]{3}\sb[/](?<file>[\s\S]+)$/.test(line)) {
             file = line.match(/^[+]{3}\sb[/](?<file>[\s\S]+)$/)?.groups?.file.replace(/^/, `${path}/`) ?? null
             lang = files[file] ?? null
-            if (lang in languageResults.data || lang in languageResults.prose)
+            const ignored = ["data", "markup", "programming", "prose"].map(type => data.shared.categories.includes(type) && lang in languageResults[type]).filter(type => type)
+            if (ignored.length)
               lang = null
             edited.add(file)
             return
           }
-          //Ignore unkonwn languages
+          //Ignore unknown languages
           if (!lang)
             return
           //Added line marker
@@ -207,8 +208,8 @@ if (/languages.analyzers.mjs$/.test(process.argv[1])) {
     }
     const {default:setup} = await import("../../app/metrics/setup.mjs")
     const {conf:{metadata}} = await setup({log:false, nosettings:true})
-    const {"commits.authoring":authoring} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
-    const data = {shared:{"commits.authoring":authoring}}
+    const {"commits.authoring":authoring, categories:_categories, "recent.categories":_recent_categories} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
+    const data = {shared:{"commits.authoring":authoring, categories:_categories, "recent.categories":_recent_categories}}
 
     //Prepare call
     const imports = await import("../../app/metrics/utils.mjs")

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -29,7 +29,7 @@ export async function indepth({login, data, imports, repositories}, {skipped}) {
       await git.clone(`https://github.com/${repo}`, ".").status()
 
       //Analyze repository
-      await analyze(arguments[0], {section:"indepth", results, path})
+      await analyze(arguments[0], {results, path})
     }
     catch (error) {
       console.debug(`metrics/compute/${login}/plugins > languages > indepth > an error occured while processing ${repo}, skipping...`)
@@ -118,7 +118,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
       await git.init().add(".").addConfig("user.name", data.shared["commits.authoring"]?.[0] ?? login).addConfig("user.email", "<>").commit("linguist").status()
 
       //Analyze repository
-      await analyze(arguments[0], {section:"recent", results, path:imports.paths.join(path, directory)})
+      await analyze(arguments[0], {results, path:imports.paths.join(path, directory)})
 
       //Since we reproduce a "partial repository" with a single commit, use number of commits retrieved instead
       results.commits = commits.length
@@ -136,7 +136,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
 }
 
 /**Analyze a single repository */
-async function analyze({login, imports, data}, {section, results, path}) {
+async function analyze({login, imports, data}, {results, path}) {
   //Gather language data
   console.debug(`metrics/compute/${login}/plugins > languages > indepth > running linguist`)
   const {results:files, languages:languageResults} = await linguist(path)
@@ -166,7 +166,7 @@ async function analyze({login, imports, data}, {section, results, path}) {
           if (/^[+]{3}\sb[/](?<file>[\s\S]+)$/.test(line)) {
             file = line.match(/^[+]{3}\sb[/](?<file>[\s\S]+)$/)?.groups?.file.replace(/^/, `${path}/`) ?? null
             lang = files[file] ?? null
-            if (["data", "markup", "programming", "prose"].map(type => data.shared[section === "recent" ? "recent.categories" : "categories"].includes(type) && lang in languageResults[type]).filter(type => type).length)
+            if (["data", "markup", "programming", "prose"].map(type => data.shared.categories.includes(type) && lang in languageResults[type]).filter(type => type).length)
               lang = null
             edited.add(file)
             return
@@ -207,8 +207,8 @@ if (/languages.analyzers.mjs$/.test(process.argv[1])) {
     }
     const {default:setup} = await import("../../app/metrics/setup.mjs")
     const {conf:{metadata}} = await setup({log:false, nosettings:true})
-    const {"commits.authoring":authoring, categories:_categories, "recent.categories":_recent_categories} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
-    const data = {shared:{"commits.authoring":authoring, categories:_categories, "recent.categories":_recent_categories}}
+    const {"commits.authoring":authoring, categories:_categories} = await metadata.plugins.base.inputs({q:{"commits.authoring":_authoring}, account:"bypass"})
+    const data = {shared:{"commits.authoring":authoring, categories:_categories}}
 
     //Prepare call
     const imports = await import("../../app/metrics/utils.mjs")

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -17,7 +17,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
     }
 
     //Load inputs
-    let {ignored, skipped, colors, aliases, details, threshold, limit, indepth, sections, categories, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({data, account, q})
+    let {ignored, skipped, colors, aliases, details, threshold, limit, indepth, sections, categories, "recent.categories":_recent_categories, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({data, account, q})
     threshold = (Number(threshold.replace(/%$/, "")) || 0) / 100
     skipped.push(...data.shared["repositories.skipped"])
     if (!limit)
@@ -57,7 +57,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
       //Recently used languages
       if ((sections.includes("recently-used"))&&(context.mode === "user")) {
         console.debug(`metrics/compute/${login}/plugins > languages > using recent analyzer`)
-        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, categories, days:_recent_days, load:_recent_load})
+        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, categories:_recent_categories, days:_recent_days, load:_recent_load})
       }
 
       //Indepth mode

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -1,5 +1,5 @@
 //Imports
-import { indepth as indepth_analyzer, recent as recent_analyzer } from "./analyzers.mjs"
+import {indepth as indepth_analyzer, recent as recent_analyzer} from "./analyzers.mjs"
 
 //Setup
 export default async function({login, data, imports, q, rest, account}, {enabled = false, extras = false} = {}) {
@@ -17,7 +17,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
     }
 
     //Load inputs
-    let {ignored, skipped, colors, aliases, details, threshold, limit, indepth, sections, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({data, account, q})
+    let {ignored, skipped, colors, aliases, details, threshold, limit, indepth, sections, categories, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({data, account, q})
     threshold = (Number(threshold.replace(/%$/, "")) || 0) / 100
     skipped.push(...data.shared["repositories.skipped"])
     if (!limit)
@@ -57,13 +57,13 @@ export default async function({login, data, imports, q, rest, account}, {enabled
       //Recently used languages
       if ((sections.includes("recently-used"))&&(context.mode === "user")) {
         console.debug(`metrics/compute/${login}/plugins > languages > using recent analyzer`)
-        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, days:_recent_days, load:_recent_load})
+        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, categories, days:_recent_days, load:_recent_load})
       }
 
       //Indepth mode
       if (indepth) {
         console.debug(`metrics/compute/${login}/plugins > languages > switching to indepth mode (this may take some time)`)
-        Object.assign(languages, await indepth_analyzer({login, data, imports, repositories}, {skipped}))
+        Object.assign(languages, await indepth_analyzer({login, data, imports, repositories}, {skipped, categories}))
         console.debug(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed} commits`)
       }
     }

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -57,7 +57,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
       //Recently used languages
       if ((sections.includes("recently-used"))&&(context.mode === "user")) {
         console.debug(`metrics/compute/${login}/plugins > languages > using recent analyzer`)
-        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, categories:_recent_categories, days:_recent_days, load:_recent_load})
+        languages["stats.recent"] = await recent_analyzer({login, data, imports, rest, account}, {skipped, categories:_recent_categories ?? categories, days:_recent_days, load:_recent_load})
       }
 
       //Indepth mode

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -97,6 +97,30 @@ inputs:
     description: Indepth languages processing (see documentation before enabling)
     type: boolean
     default: false
+    
+  # GitHub language categories to display in most-used section
+  plugin_languages_categories:
+    description: Language categories to display
+    type: array
+    format: comma-separated
+    values:
+      - data
+      - markup
+      - programming
+      - prose
+    default: markup, programming
+    
+  # GitHub language categories to display in recently-used section
+  plugin_languages_recent_categories:
+    description: Language categories to display (for recently used section)
+    type: array
+    format: comma-separated
+    values:
+      - data
+      - markup
+      - programming
+      - prose
+    default: markup, programming
 
   # Number of activity events to load (for recently used languages statistics)
   # A high number will consume more requests

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -110,6 +110,18 @@ inputs:
       - prose
     default: markup, programming
 
+  # GitHub language categories to display in recently-used section
+  plugin_languages_recent_categories:
+    description: Language categories to display (for recently used section)
+    type: array
+    format: comma-separated
+    values:
+      - data
+      - markup
+      - programming
+      - prose
+    default: markup, programming
+
   # Number of activity events to load (for recently used languages statistics)
   # A high number will consume more requests
   plugin_languages_recent_load:

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -98,21 +98,9 @@ inputs:
     type: boolean
     default: false
     
-  # GitHub language categories to display in most-used section
+  # GitHub language categories to display
   plugin_languages_categories:
     description: Language categories to display
-    type: array
-    format: comma-separated
-    values:
-      - data
-      - markup
-      - programming
-      - prose
-    default: markup, programming
-    
-  # GitHub language categories to display in recently-used section
-  plugin_languages_recent_categories:
-    description: Language categories to display (for recently used section)
     type: array
     format: comma-separated
     values:

--- a/source/plugins/languages/tests.yml
+++ b/source/plugins/languages/tests.yml
@@ -11,7 +11,6 @@
     plugin_languages: yes
     plugin_languages_ignored: html, css, dockerfile
 
-
 - name: Language plugin (skipped repositories)
   uses: lowlighter/metrics@latest
   with:
@@ -40,6 +39,13 @@
     plugin_languages: yes
     plugin_languages_threshold: 2%
 
+- name: Language plugin (with categories)
+  uses: lowlighter/metrics@latest
+  with:
+    token: MOCKED_TOKEN
+    plugin_languages: yes
+    plugin_languages_categories: programming, data
+
 - name: Language plugin (complete)
   uses: lowlighter/metrics@latest
   with:
@@ -50,3 +56,4 @@
     plugin_languages_colors: rainbow
     plugin_languages_details: bytes-size, percentage
     plugin_languages_threshold: 2%
+    plugin_languages_categories: programming, markup, data


### PR DESCRIPTION
- Implement #341

Adds array options `plugin_languages_categories` and `plugin_languages_recent_categories` which configure which Linguist categories (`data, markup, programming, prose`) to display.

Test using `plugin_languages_categories: programming`:

![image](https://user-images.githubusercontent.com/42429413/129460264-cf127ea8-15da-4873-bc7c-8a2ad514947b.png)

Test using `programming` for most-used and `markup,data,prose` for recent:

![image](https://user-images.githubusercontent.com/42429413/129460864-311471ac-fa2c-44b7-933b-23c17dbbd341.png)
