### PR TITLE
Move non-Node script from `package.json` to workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,16 +2,15 @@ name: Build, test, analyze and publish
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
       - '**/*.md'
       - '**/*.png'
   workflow_dispatch:
 
 jobs:
-
   # Run linter to ensure new code respect coding rules
   lint:
     name: Lint code
@@ -36,16 +35,16 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
-    needs: [ lint ]
+    needs: [lint]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Setup Dprint
+      - name: Format code with dprint
         run: |
           curl -fsSL https://dprint.dev/install.sh | sh
           echo "$HOME/.dprint/bin" >> $GITHUB_PATH
-      - name: Format code
-        run: npm run fmt
+          dprint fmt --config .github/config/dprint.json
+          npm run format
       - name: Build lowlighter/metrics:${{ github.head_ref || 'master' }}
         run: docker build -t lowlighter/metrics:$(echo ${{ github.head_ref || 'master' }} | sed 's/\//-/g') .
       - name: Run tests
@@ -55,7 +54,7 @@ jobs:
   analyze:
     name: Analyze code
     runs-on: ubuntu-latest
-    needs: [ lint ]
+    needs: [lint]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -71,7 +70,7 @@ jobs:
   format:
     name: Format code
     runs-on: ubuntu-latest
-    needs: [ build, analyze ]
+    needs: [build, analyze]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -99,7 +98,7 @@ jobs:
   update-indexes:
     name: Publish rebuilt metrics indexes
     runs-on: ubuntu-latest
-    needs: [ build, analyze, format ]
+    needs: [build, analyze, format]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -117,7 +116,7 @@ jobs:
   update-main:
     name: Rebase main on master
     runs-on: ubuntu-latest
-    needs: [ update-indexes ]
+    needs: [update-indexes]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -139,7 +138,7 @@ jobs:
   docker-master:
     name: Publish master to GitHub registry
     runs-on: ubuntu-latest
-    needs: [ update-indexes ]
+    needs: [update-indexes]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -164,7 +163,7 @@ jobs:
   action-master-test:
     name: Test lowlighter/metrics@master
     runs-on: ubuntu-latest
-    needs: [ docker-master ]
+    needs: [docker-master]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Run tests
@@ -181,7 +180,7 @@ jobs:
   docker-release:
     name: Publish release to GitHub registry
     runs-on: ubuntu-latest
-    needs: [ action-master-test ]
+    needs: [action-master-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -203,7 +202,7 @@ jobs:
   update-latest:
     name: Rebase latest on master
     runs-on: ubuntu-latest
-    needs: [ docker-release ]
+    needs: [docker-release]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -227,7 +226,7 @@ jobs:
   action-latest-test:
     name: Test lowlighter/metrics@latest
     runs-on: ubuntu-latest
-    needs: [ update-latest ]
+    needs: [update-latest]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Run tests
@@ -243,7 +242,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [ action-latest-test ]
+    needs: [action-latest-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -265,7 +264,7 @@ jobs:
   deploy-master:
     name: Deploy lowlighter/metrics@master
     runs-on: ubuntu-latest
-    needs: [ action-master-test ]
+    needs: [action-master-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[deploy]')
     steps:
       - name: Deploy web instance

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,15 +2,16 @@ name: Build, test, analyze and publish
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
     paths-ignore:
       - '**/*.md'
       - '**/*.png'
   workflow_dispatch:
 
 jobs:
+
   # Run linter to ensure new code respect coding rules
   lint:
     name: Lint code
@@ -35,7 +36,7 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [ lint ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -54,7 +55,7 @@ jobs:
   analyze:
     name: Analyze code
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [ lint ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -70,7 +71,7 @@ jobs:
   format:
     name: Format code
     runs-on: ubuntu-latest
-    needs: [build, analyze]
+    needs: [ build, analyze ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -98,7 +99,7 @@ jobs:
   update-indexes:
     name: Publish rebuilt metrics indexes
     runs-on: ubuntu-latest
-    needs: [build, analyze, format]
+    needs: [ build, analyze, format ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -116,7 +117,7 @@ jobs:
   update-main:
     name: Rebase main on master
     runs-on: ubuntu-latest
-    needs: [update-indexes]
+    needs: [ update-indexes ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -138,7 +139,7 @@ jobs:
   docker-master:
     name: Publish master to GitHub registry
     runs-on: ubuntu-latest
-    needs: [update-indexes]
+    needs: [ update-indexes ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
@@ -163,7 +164,7 @@ jobs:
   action-master-test:
     name: Test lowlighter/metrics@master
     runs-on: ubuntu-latest
-    needs: [docker-master]
+    needs: [ docker-master ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Run tests
@@ -180,7 +181,7 @@ jobs:
   docker-release:
     name: Publish release to GitHub registry
     runs-on: ubuntu-latest
-    needs: [action-master-test]
+    needs: [ action-master-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -202,7 +203,7 @@ jobs:
   update-latest:
     name: Rebase latest on master
     runs-on: ubuntu-latest
-    needs: [docker-release]
+    needs: [ docker-release ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -226,7 +227,7 @@ jobs:
   action-latest-test:
     name: Test lowlighter/metrics@latest
     runs-on: ubuntu-latest
-    needs: [update-latest]
+    needs: [ update-latest ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Run tests
@@ -242,7 +243,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [action-latest-test]
+    needs: [ action-latest-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[release]')
     steps:
       - name: Checkout repository
@@ -264,7 +265,7 @@ jobs:
   deploy-master:
     name: Deploy lowlighter/metrics@master
     runs-on: ubuntu-latest
-    needs: [action-master-test]
+    needs: [ action-master-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, '[deploy]')
     steps:
       - name: Deploy web instance

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "quickstart": "node .github/quickstart/index.mjs",
     "preview": "node .github/preview.mjs",
     "linter": "eslint source/**/*.mjs --quiet",
+    "format": "eslint source/**/*.mjs --fix",
     "dev": "nodemon source/app/web/index.mjs -e mjs,css,ejs,json",
     "postinstall": "node node_modules/puppeteer/install.js",
-    "fmt": "dprint fmt --config .github/config/dprint.json && npx eslint source/**/*.mjs --fix",
     "indepth": "node source/plugins/languages/analyzers.mjs"
   },
   "repository": {


### PR DESCRIPTION
Script `npm run fmt` uses package [`dprint`](https://www.npmjs.com/package/dprint) which is not included in `package.json`'s `devDependencies`. 

https://github.com/lowlighter/metrics/blob/8f49d1076a1f2dfdfaab3edb62dedfddba0dfbb0/package.json#L15
https://github.com/lowlighter/metrics/blob/8f49d1076a1f2dfdfaab3edb62dedfddba0dfbb0/package.json#L63-L68

Module `dprint` is not used in a Node context so should not be placed in `package.json`.
It is just used in a CLI context:
https://github.com/lowlighter/metrics/blob/aabb21fbd71290c1874acefe8a9d125f81f80e75/.github/workflows/workflow.yml#L43-L48
This means that line 48 can just be changed to the content of the `fmt` script.
This would avoid an npm script being unrunnable outside of the CI process.

This PR inlines it in the `workflow.yml` file and replaces the latter half of script `fmt` (`eslint`...`--fix`) with script `format`.