### PR TITLE
Fix typo in repository plugin example

### DIFF
--- a/source/plugins/repositories/README.md
+++ b/source/plugins/repositories/README.md
@@ -22,5 +22,5 @@ Because of limitations of using SVG inside of `<img>` tags, people won't be able
   with:
     # ... other options
     plugin_repositories: yes
-    plugin_repositories_list: lowlighter/metrics, denoland/deno  # List of repositories you want to feature
+    plugin_repositories_featured: lowlighter/metrics, denoland/deno  # List of repositories you want to feature
 ```


### PR DESCRIPTION
The current example of repositories plugin uses `plugin_repositories_lists`, but it should be `plugin_repositories_featured`.

<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->
