### PR TITLE
fix(core): Account age inaccuracy due to leap years

### DIFF
--- a/source/plugins/core/index.mjs
+++ b/source/plugins/core/index.mjs
@@ -88,11 +88,14 @@ export default async function({login, q}, {conf, data, rest, graphql, plugins, q
   computed.commits += data.user.contributionsCollection.totalCommitContributions + data.user.contributionsCollection.restrictedContributionsCount
 
   //Compute registration date
-  const diff = (Date.now() - (new Date(data.user.createdAt)).getTime()) / (365 * 24 * 60 * 60 * 1000)
-  const years = Math.floor(diff)
-  const months = Math.floor((diff - years) * 12)
+  const now = Date.now()
+  const created = new Date(data.user.createdAt)
+  const diff = now - created
+  const years = new Date(years).getFullUTCYear() - 1970
+  const months = now.getUTCMonth() - created.getUTCMonth() + 12 * years
+  const days = ~~(diff / (1000 * 60 * 60 * 24))
   computed.registered = {years, months, diff}
-  computed.registration = years ? `${years} year${imports.s(years)} ago` : months ? `${months} month${imports.s(months)} ago` : `${Math.ceil(diff * 365)} day${imports.s(Math.ceil(diff * 365))} ago`
+  computed.registration = years ? `${years} year${imports.s(years)} ago` : months ? `${months} month${imports.s(months)} ago` : `${days} day${imports.s(days)} ago`
   computed.cakeday = years > 1 ? [new Date(), new Date(data.user.createdAt)].map(date => date.toISOString().match(/(?<mmdd>\d{2}-\d{2})(?=T)/)?.groups?.mmdd).every((v, _, a) => v === a[0]) : false
 
   //Compute calendar

--- a/source/plugins/core/index.mjs
+++ b/source/plugins/core/index.mjs
@@ -93,7 +93,7 @@ export default async function({login, q}, {conf, data, rest, graphql, plugins, q
   const diff = now - created
   const years = new Date(years).getFullUTCYear() - 1970
   const months = now.getUTCMonth() - created.getUTCMonth() + 12 * years
-  const days = ~~(diff / (1000 * 60 * 60 * 24))
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
   computed.registered = {years, months, diff}
   computed.registration = years ? `${years} year${imports.s(years)} ago` : months ? `${months} month${imports.s(months)} ago` : `${days} day${imports.s(days)} ago`
   computed.cakeday = years > 1 ? [new Date(), new Date(data.user.createdAt)].map(date => date.toISOString().match(/(?<mmdd>\d{2}-\d{2})(?=T)/)?.groups?.mmdd).every((v, _, a) => v === a[0]) : false


### PR DESCRIPTION
By converting the diff to a date, the date since 1970 is calculated. The
year of that date minus 1970 would then equal the number of years that
have passed, taking leap years into account.

Resolves #497

***

As a side note, I wanted to write tests for this, but making all the computed values of the core plugin testable would require a lot of refactoring, it seems.
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->
