### PR TITLE
feat(plugins/isocalendar): make stats based on overall account contributions rather than restricted to `isocalendar.duration`

### DIFF
--- a/source/plugins/isocalendar/index.mjs
+++ b/source/plugins/isocalendar/index.mjs
@@ -89,7 +89,7 @@ export default async function({login, data, graphql, q, imports, queries, accoun
   }
 }
 
-/** Compute max and current streaks */
+/**Compute max and current streaks */
 async function statistics({login, data, graphql, queries}) {
   let average = 0, max = 0, streak = {max:0, current:0}, values = []
   const now = new Date()

--- a/source/plugins/isocalendar/index.mjs
+++ b/source/plugins/isocalendar/index.mjs
@@ -39,16 +39,7 @@ export default async function({login, data, graphql, q, imports, queries, accoun
 
     //Compute the highest contributions in a day, streaks and average commits per day
     console.debug(`metrics/compute/${login}/plugins > isocalendar > computing stats`)
-    let average = 0, max = 0, streak = {max:0, current:0}, values = []
-    for (const week of calendar.weeks) {
-      for (const day of week.contributionDays) {
-        values.push(day.contributionCount)
-        max = Math.max(max, day.contributionCount)
-        streak.current = day.contributionCount ? streak.current + 1 : 0
-        streak.max = Math.max(streak.max, streak.current)
-      }
-    }
-    average = (values.reduce((a, b) => a + b, 0) / values.length).toFixed(2).replace(/[.]0+$/, "")
+    const {streak, max, average} = await statistics({login, data, graphql, queries})
 
     //Compute SVG
     console.debug(`metrics/compute/${login}/plugins > isocalendar > computing svg render`)
@@ -96,4 +87,31 @@ export default async function({login, data, graphql, q, imports, queries, accoun
       throw error
     throw {error:{message:"An error occured", instance:error}}
   }
+}
+
+/** Compute max and current streaks */
+async function statistics({login, data, graphql, queries}) {
+  let average = 0, max = 0, streak = {max:0, current:0}, values = []
+  const now = new Date()
+  for (let from = new Date(data.user.createdAt); from < now;) {
+    //Load contribution calendar
+    let to = new Date(from)
+    to.setFullYear(to.getFullYear() + 1)
+    if (to > now)
+      to = now
+    console.debug(`metrics/compute/${login}/plugins > isocalendar > loading calendar from "${from.toISOString()}" to "${to.toISOString()}"`)
+    const {user:{calendar:{contributionCalendar:{weeks}}}} = await graphql(queries.isocalendar.calendar({login, from:from.toISOString(), to:to.toISOString()}))
+    from = to
+    //Compute streaks
+    for (const week of weeks) {
+      for (const day of week.contributionDays) {
+        values.push(day.contributionCount)
+        max = Math.max(max, day.contributionCount)
+        streak.current = day.contributionCount ? streak.current + 1 : 0
+        streak.max = Math.max(streak.max, streak.current)
+      }
+    }
+  }
+  average = (values.reduce((a, b) => a + b, 0) / values.length).toFixed(2).replace(/[.]0+$/, "")
+  return {streak, max, average}
 }

--- a/source/plugins/isocalendar/metadata.yml
+++ b/source/plugins/isocalendar/metadata.yml
@@ -1,5 +1,5 @@
 name: "📅 Isometric commit calendar"
-cost: 2-3 REST requests
+cost: 1-2 GraphQL requests + 1 GraphQL request per year
 category: github
 index: 0
 supports:


### PR DESCRIPTION
Isocalendar additional stats are now computed over all account contributions, rather on the loaded isometrics view to avoid capping at `isocalendar.duration` time window