### PR TITLE
Fix: typo

### DIFF
--- a/source/app/web/statics/about/script.js
+++ b/source/app/web/statics/about/script.js
@@ -96,7 +96,7 @@
         return this.metrics?.rendered.plugins.achievements.list?.filter(({ leaderboard }) => leaderboard).sort((a, b) => a.leaderboard.type.localeCompare(b.leaderboard.type)) ?? []
       },
       achievements() {
-        return this.metrics?.rendered.plugins.achievements.list?.filter(({ leaderboard }) => !leaderboard).filter(({ title }) => !/(?:automater|octonaut|infographile)/i.test(title)) ?? []
+        return this.metrics?.rendered.plugins.achievements.list?.filter(({ leaderboard }) => !leaderboard).filter(({ title }) => !/(?:automator|octonaut|infographile)/i.test(title)) ?? []
       },
       introduction() {
         return this.metrics?.rendered.plugins.introduction?.text ?? ""

--- a/source/plugins/achievements/list/users.mjs
+++ b/source/plugins/achievements/list/users.mjs
@@ -324,13 +324,13 @@ export default async function({list, login, data, computed, imports, graphql, qu
     })
   }
 
-  //Automater
+  //Automator
   {
     const value = process.env.GITHUB_ACTIONS
     const unlock = null
 
     list.push({
-      title:"Automater",
+      title:"Automator",
       text:"Use GitHub Actions to automate profile updates",
       icon:'<g transform="translate(4 5)" stroke-width="2" fill="none" fill-rule="evenodd"><g stroke-linecap="round" stroke-linejoin="round"><path stroke="#primary" d="M26.478 22l.696 2.087 3.478.696v2.782l-3.478 1.392-.696 1.39 1.392 3.48-1.392 1.39L23 33.827l-1.391.695L20.217 38h-2.782l-1.392-3.478-1.39-.696-3.48 1.391-1.39-1.39 1.39-3.48-.695-1.39L7 27.565v-2.782l3.478-1.392.696-1.391-1.391-3.478 1.39-1.392 3.48 1.392 1.39-.696 1.392-3.478h2.782l1.392 3.478 1.391.696 3.478-1.392 1.392 1.392z"/><path stroke="#secondary" d="M24.779 12.899l-1.475-2.212 1.475-1.475 2.95 1.475 1.474-.738.737-2.934h2.212l.737 2.934 1.475.738 2.95-1.475 1.474 1.475-1.475 2.949.738 1.475 2.949.737v2.212l-2.95.737-.737 1.475 1.475 2.949-1.475 1.475-2.949-1.475"/></g><path stroke="#primary" stroke-linecap="round" d="M5.932 5.546l7.082 6.931"/><path stroke="#secondary" stroke-linecap="round" d="M32.959 31.99l8.728 8.532"/><circle stroke="#secondary" cx="44" cy="43" r="3"/><circle stroke="#primary" cx="13" cy="2" r="2"/><circle stroke="#secondary" cx="35" cy="44" r="2"/><circle stroke="#secondary" cx="3" cy="12" r="2"/><circle stroke="#primary" cx="45" cy="34" r="2"/><path d="M3.832 0a3 3 0 110 6 3 3 0 010-6zM8.04 10.613l2.1-.613M10.334 9.758l1.914-5.669" stroke="#primary" stroke-linecap="round"/><path stroke="#secondary" stroke-linecap="round" d="M40.026 35.91l-2.025.591M35.695 41.965l1.843-5.326"/><path d="M16 2h23.038a6 6 0 016 6v24.033" stroke="#primary" stroke-linecap="round"/><path d="M32.038 44.033H9a6 6 0 01-6-6V14" stroke="#secondary" stroke-linecap="round"/><path d="M17.533 22.154l5.113 3.22a1 1 0 01-.006 1.697l-5.113 3.17a1 1 0 01-1.527-.85V23a1 1 0 011.533-.846zm11.58-7.134v-.504a1 1 0 011.53-.85l3.845 2.397a1 1 0 01-.006 1.701l-3.846 2.358" stroke="#primary" stroke-linecap="round" stroke-linejoin="round"/></g>',
       rank:value ? "$" : "X",

--- a/source/plugins/achievements/metadata.yml
+++ b/source/plugins/achievements/metadata.yml
@@ -55,7 +55,7 @@ inputs:
     type: array
     format: comma-separated
     default: ""
-    example: octonaut, automater, explorer
+    example: octonaut, automator, explorer
 
   # List of unlocked achievements to display
   # Names must be given in lower case, without rank adjective
@@ -65,4 +65,4 @@ inputs:
     type: array
     format: comma-separated
     default: ""
-    example: octonaut, automater, explorer
+    example: octonaut, automator, explorer


### PR DESCRIPTION
This changes `automater` to `automator`.

When looking at the output of a metrics workflow run, I happened to see `automater`, and the spelling felt incorrect.
I'm not sure if "automator" or "automater" is actually accepted in any common dictionaries yet, but, [according to thefreedictionary.com, rule 2.5](https://www.thefreedictionary.com/Commonly-Confused-Suffixes-er-or-ar.htm), words that end in -ate (e.g. autom*ate*), typically get converted to a word that ends in -or.

This was pretty much a naive find and replace. Please let me know if additional changes are needed :slightly_smiling_face:
