### PR TITLE
feat(plugins/notable): add support for `plugin_notable_from` to display contributions from repositories hosted by user accounts

### DIFF
--- a/source/plugins/notable/README.md
+++ b/source/plugins/notable/README.md
@@ -21,6 +21,7 @@ The *notable* plugin displays badges of organization where you commited at least
   with:
     # ... other options
     plugin_notable: yes
-    plugin_notable_filter: stars:>500 # Only display repositories with 500 stars or more (syntax based on GitHub search query)
+    plugin_notable_filter: stars:>500    # Only display repositories with 500 stars or more (syntax based on GitHub search query)
+    plugin_notable_from: organization    # Only display contributions within organization repositories
     plugin_notable_repositories: yes     # Display repositories name instead of only organization name
 ```

--- a/source/plugins/notable/metadata.yml
+++ b/source/plugins/notable/metadata.yml
@@ -21,7 +21,18 @@ inputs:
     default: ""
     example: stars:>500 forks:>100
 
+  # Filter repositories depending on which type of account it is hosted
+  plugin_notable_from:
+    description: Filter by repository host account type
+    type: string
+    default: organization
+    values:
+      - all           #
+      - organization  # Only hosted by organization accounts
+      - user          # Only hosted by user accounts
+
   # Also display repository name along with organization name
+  # Note that repositories hosted by user account will always be displayed fully
   plugin_notable_repositories:
     description: Also display repository name
     type: boolean

--- a/source/templates/classic/partials/notable.ejs
+++ b/source/templates/classic/partials/notable.ejs
@@ -16,10 +16,10 @@
     <% } else { %>
       <% if (plugins.notable.contributions.length) { %>
         <div class="row organization contributions">
-          <% for (const {name, avatar} of plugins.notable.contributions) { %>
+          <% for (const {name, avatar, organization} of plugins.notable.contributions) { %>
             <div class="organization contribution">
-              <img class="organization avatar" src="<%= avatar %>" width="16" height="16" />
-              <span class="organization name">@<%= name %></span>
+              <img class="<%= organization ? "organization" : "" %> avatar" src="<%= avatar %>" width="16" height="16" />
+              <span class="name">@<%= name %></span>
             </div>
           <% } %>
         </div>


### PR DESCRIPTION
Can now display contributions from repositories hosted by user accounts