### PR TITLE
fix(plugins/stackoverflow): fix markdown errors display issues

### DIFF
--- a/source/app/metrics/utils.mjs
+++ b/source/app/metrics/utils.mjs
@@ -217,7 +217,7 @@ export async function which(command) {
 }
 
 /**Code hightlighter */
-export async function highlight(code, lang) {
+export function highlight(code, lang) {
   return lang in prism.languages ? prism.highlight(code, prism.languages[lang]) : code
 }
 


### PR DESCRIPTION
For some reason the `hightlight` function was labeled as `async` while it is synchronous, confusing marked-js and causing render errors for code blocks

Closes #600