### PR TITLE
feat(core): add `config_base64` option

### DIFF
--- a/source/plugins/core/index.mjs
+++ b/source/plugins/core/index.mjs
@@ -6,8 +6,14 @@
 //Setup
 export default async function({login, q}, {conf, data, rest, graphql, plugins, queries, account, convert, template}, {pending, imports}) {
   //Load inputs
-  const {"config.animations":animations, "config.display":display, "config.timezone":_timezone, "debug.flags":dflags} = imports.metadata.plugins.core.inputs({data, account, q})
+  const {"config.animations":animations, "config.display":display, "config.timezone":_timezone, "config.base64":_base64, "debug.flags":dflags} = imports.metadata.plugins.core.inputs({data, account, q})
   imports.metadata.templates[template].check({q, account, format:convert})
+
+  //Base64 images
+  if (!_base64) {
+    console.debug(`metrics/compute/${login} > base64 for images has been disabled`)
+    imports.imgb64 = url => url
+  }
 
   //Init
   const computed = {commits:0, sponsorships:0, licenses:{favorite:"", used:{}, about:{}}, token:{}, repositories:{watchers:0, stargazers:0, issues_open:0, issues_closed:0, pr_open:0, pr_closed:0, pr_merged:0, forks:0, forked:0, releases:0, deployments:0, environments:0}}

--- a/source/plugins/core/metadata.yml
+++ b/source/plugins/core/metadata.yml
@@ -183,6 +183,13 @@ inputs:
     type: boolean
     default: yes
 
+  # Encode images links into base64 data
+  # Advised to be true when generating images and false when generating texts or JSON
+  config_base64:
+    description: Encode images links into base64 data
+    type: boolean
+    default: yes
+
   # Configure padding for output image (percentage value)
   # It can be used to add padding to generated metrics if rendering is cropped or has too much empty space
   # Specify one value (for both width and height) or two values (one for width and one for height)


### PR DESCRIPTION
Add `config_base64` option to enable/disable encoding of images in base64.
Toggling this off can be useful when generating JSON data to avoid large texts chunks due to avatar and other images encoded values