### PR TITLE
fix(plugins/base): automatic halving of repositories batching when fetching them

### DIFF
--- a/source/plugins/base/index.mjs
+++ b/source/plugins/base/index.mjs
@@ -95,7 +95,7 @@ export default async function({login, graphql, rest, data, q, queries, imports},
           }
           catch (error) {
             console.debug(`metrics/compute/${login}/base > failed to retrieve ${_batch} repositories after ${cursor}, this is probably due to an API timeout, halving batch`)
-            _batch = Math.floo(_batch/2)
+            _batch = Math.floor(_batch/2)
             if (_batch < 1) {
               console.debug(`metrics/compute/${login}/base > failed to retrieve repositories, cannot halve batch anymore`)
               throw error

--- a/source/plugins/base/index.mjs
+++ b/source/plugins/base/index.mjs
@@ -89,7 +89,20 @@ export default async function({login, graphql, rest, data, q, queries, imports},
         data.user[type].nodes = data.user[type].nodes ?? []
         do {
           console.debug(`metrics/compute/${login}/base > retrieving ${type} after ${cursor}`)
-          const {[account]:{[type]:{edges = [], nodes = []} = {}}} = await graphql(queries.base.repositories({login, account, type, after:cursor ? `after: "${cursor}"` : "", repositories:Math.min(repositories, {user:_batch, organization:Math.min(25, _batch)}[account]), ...options}))
+          const request = {}
+          try {
+            Object.assign(request, await graphql(queries.base.repositories({login, account, type, after:cursor ? `after: "${cursor}"` : "", repositories:Math.min(repositories, {user:_batch, organization:Math.min(25, _batch)}[account]), ...options})))
+          }
+          catch (error) {
+            console.debug(`metrics/compute/${login}/base > failed to retrieve ${_batch} repositories after ${cursor}, this is probably due to an API timeout, halving batch`)
+            _batch = Math.floo(_batch/2)
+            if (_batch < 1) {
+              console.debug(`metrics/compute/${login}/base > failed to retrieve repositories, cannot halve batch anymore`)
+              throw error
+            }
+            continue
+          }
+          const {[account]:{[type]:{edges = [], nodes = []} = {}}} = request
           cursor = edges?.[edges?.length - 1]?.cursor
           data.user[type].nodes.push(...nodes)
           pushed = nodes.length


### PR DESCRIPTION
*(Followup of #598)*

When fetching repositories, if the request timeout for a given repositories batch settings, it'll retry automatically by halving values (i.e. fetch 100 repositories, then 50, 25, 12, 6, 3, 1). In case of timeout for fetching a single repository, the plugin will fail.

This should avoid "unlucky" runs for "huge users" by providing a higher success rate