### PR TITLE
fix(plugins/code,habits,languages): support basic login as authoring

### DIFF
--- a/source/plugins/code/index.mjs
+++ b/source/plugins/code/index.mjs
@@ -32,7 +32,8 @@ export default async function({login, q, imports, data, rest, account}, {enabled
           .filter(event => visibility === "public" ? event.public : true)
           .flatMap(({payload}) => Promise.all(payload.commits.map(async commit => (await rest.request(commit.url)).data)))])]
           .flat()
-          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)))
+          .filter(({parents}) => parents.length <= 1)
+          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring)||author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)).length)
         )
       }
     }

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -45,7 +45,7 @@ export default async function({login, data, rest, imports, q, account}, {enabled
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
-          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)).length)
+          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring)||author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)).length)
           .map(async commit => (await rest.request(commit)).data.files),
       ),
     ]

--- a/source/plugins/languages/analyzers.mjs
+++ b/source/plugins/languages/analyzers.mjs
@@ -86,7 +86,7 @@ export async function recent({login, data, imports, rest, account}, {skipped = [
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
-          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)).length)
+          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring)||author?.email?.toLocaleLowerCase().includes(authoring)||author?.name?.toLocaleLowerCase().includes(authoring)).length)
           .map(commit => commit.url)
           .map(async commit => (await rest.request(commit)).data),
       )


### PR DESCRIPTION
`commits_authoring` defaults to `.user.login` (unless overidden) but it actually doesn't match in most of plugin using this option which ends up with no results though it should