### PR TITLE
fix: update plugin_poopmap_days to number type

### DIFF
--- a/source/plugins/poopmap/metadata.yml
+++ b/source/plugins/poopmap/metadata.yml
@@ -21,7 +21,7 @@ inputs:
   # Time range to use for displayed stats
   plugin_poopmap_days:
     description: PoopMap time range
-    type: string
+    type: number
     values:
       - 7     # Last week
       - 30    # Last month


### PR DESCRIPTION
This PR fixes the issue where `plugin_poopmap_days` is always `7`, regardless of input value