### PR TITLE
fix(app/action): base64-to-cache regex

### DIFF
--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -365,7 +365,7 @@ async function wait(seconds) {
 
     //Cache
     if (/markdown/.test(convert)) {
-      const regex = /(?<match><img class="metrics-cachable" data-name="(?<name>[\s\S]+?)" src="data:image[/](?<format>(?:svg[+]xml)|jpeg|png);base64,(?<content>[/+=\w]+)">)/g
+      const regex = /(?<match><img class="metrics-cachable" data-name="(?<name>[\s\S]+?)" src="data:image[/](?<format>(?:svg[+]xml)|jpeg|png);base64,(?<content>[/+=\w]+?)">)/g
       let matched = null
       while (matched = regex.exec(rendered)?.groups) { //eslint-disable-line no-cond-assign
         const {match, name, format, content} = matched

--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -365,7 +365,7 @@ async function wait(seconds) {
 
     //Cache
     if (/markdown/.test(convert)) {
-      const regex = /(?<match><img class="metrics-cachable" data-name="(?<name>[\s\S]+?)" src="data:image[/](?<format>(?:svg[+]xml)|jpeg|png);base64,(?<content>[/+=\w]+?)">)/g
+      const regex = /(?<match><img class="metrics-cachable" data-name="(?<name>[\s\S]+?)" src="data:image[/](?<format>(?:svg[+]xml)|jpeg|png);base64,(?<content>[/+=\w]+?)">)/
       let matched = null
       while (matched = regex.exec(rendered)?.groups) { //eslint-disable-line no-cond-assign
         const {match, name, format, content} = matched


### PR DESCRIPTION
Fix an issue with the base64-to-cache regex replacer for markdown template

Because of the `/g` flag, `regex.exec` was starting from `lastIndex` but in the meantime `rendered` variable was modified in-place, causing "jumps" in the loop

