### PR TITLE
feat(action): add `retries_output_action` and `retries_delay_output_action`

### DIFF
--- a/source/plugins/core/README.md
+++ b/source/plugins/core/README.md
@@ -228,10 +228,13 @@ It also possible to alter output condition using `output_condition` option, whic
     output_action: pull-request-merge
 ```
 
-### ♻️ Retrying automatically failed rendering
+### ♻️ Retrying automatically failed rendering and output action
 
 Rendering is subject to external factors and can fail from time to time.
 It is possible to mitigate this issue using `retries` and `retries_delay` options to automatically retry later metrics rendering and avoid workflow fails.
+
+Output action is also subject to GitHub API rate-limiting and status and can fail from time to time.
+It is possible to mitigate this issue using `retries_output_action` and `retries_delay_output_action` options to automatically retry later metrics output action and avoid workflow fails. As this is a separate step from rendering, metrics rendering won't be computed again during this phase.
 
 #### ℹ️ Examples workflows
 
@@ -241,6 +244,8 @@ It is possible to mitigate this issue using `retries` and `retries_delay` option
     # ... other options
     retries: 3
     retries_delay: 300
+    retries_output_action: 5
+    retries_delay_output_action: 120
 ```
 
 ### 💱 Convert output to PNG/JPEG or JSON

--- a/source/plugins/core/metadata.yml
+++ b/source/plugins/core/metadata.yml
@@ -244,6 +244,22 @@ inputs:
     min: 0
     max: 3600
 
+  # Number of retries in case output action fail
+  retries_output_action:
+    description: Number of retries (output action)
+    type: number
+    default: 5
+    min: 1
+    max: 10
+
+  # Time to wait (in seconds) before each retry (output action)
+  retries_delay_output_action:
+    description: Time to wait (in seconds) before each retry (output action)
+    type: number
+    default: 120
+    min: 0
+    max: 3600
+
   # ====================================================================================
   # 🚧 Options below are mostly used for testing
 


### PR DESCRIPTION
Closes #728

Add a retry wrapper around different output actions along with two new options `retries_output_action` and `retries_delay_output_action` to automatically retry upon API errors (rate-limit, connection reset, etc.)