### PR TITLE
fix(app/utils): indent for code block with languages hightlighting

### DIFF
--- a/source/app/metrics/utils.mjs
+++ b/source/app/metrics/utils.mjs
@@ -288,8 +288,12 @@ export async function markdown(text, {mode = "inline", codelines = Infinity} = {
   //Trim code snippets
   rendered = rendered.replace(/(?<open><code[\s\S]*?>)(?<code>[\s\S]*?)(?<close><\/code>)/g, (m, open, code, close) => { //eslint-disable-line max-params
     const lines = code.trim().split("\n")
-    if ((lines.length > 1) && (!/class="[\s\S]*"/.test(open)))
-      open = open.replace(/>/g, ' class="language-multiline" xml:space="preserve">')
+    if (lines.length > 1) {
+      if (/class=".*language-[\s\S]+?.*"/.test(open))
+        open = open.replace(/>/g, ` class="language-multiline ${open.match(/class="(?<class>[\s\S]+)"/)?.groups.class}" xml:space="preserve">`)
+      else if (!/class="[\s\S]*"/.test(open))
+        open = open.replace(/>/g, ' class="language-multiline" xml:space="preserve">')
+    }
     return `${open}${lines.slice(0, codelines).join("\n")}${lines.length > codelines ? `\n<span class="token trimmed">(${lines.length - codelines} more ${lines.length - codelines === 1 ? "line was" : "lines were"} trimmed)</span>` : ""}${close}`
   })
   return rendered


### PR DESCRIPTION
Closes #691
The issue was only fixed for code blocks without languages highlighting