### PR TITLE
feat(plugins/starlists): add new starlists plugin

### DIFF
--- a/source/app/web/statics/app.placeholder.js
+++ b/source/app/web/statics/app.placeholder.js
@@ -743,6 +743,23 @@
             },
           })
           : null),
+        //Starlists
+        ...(set.plugins.enabled.starlists
+          ? ({
+            starlists: {
+              lists: new Array(Number(options["starlists.limit"])).fill(null).map(_ => ({
+                link: faker.internet.url(),
+                name: `${faker.random.arrayElement(["😎", "🥳", "🧐", "😂", "😁"])} ${faker.lorem.word()}`,
+                description: faker.lorem.sentence(),
+                count: faker.datatype.number(100),
+                repositories: new Array(Number(options["starlists.limit.repositories"])).fill(null).map((_, i) => ({
+                  description: !i ? "📊 An image generator with 20+ metrics about your GitHub account such as activity, community, repositories, coding habits, website performances, music played, starred topics, etc. that you can put on your profile or elsewhere !" : faker.lorem.sentence(),
+                  name: !i ? "lowlighter/metrics" : `${faker.random.word()}/${faker.random.word()}`,
+                }))
+              })),
+            },
+          })
+          : null),
         //Repositories
         ...(set.plugins.enabled.repositories
           ? ({

--- a/source/plugins/starlists/README.md
+++ b/source/plugins/starlists/README.md
@@ -1,0 +1,25 @@
+### 💫 Starlists
+
+The *starlists* plugin displays your recently star lists.
+
+<table>
+  <td align="center">
+    <img src="https://github.com/lowlighter/lowlighter/blob/master/metrics.plugin.starlist.svg">
+    <img width="900" height="1" alt="">
+  </td>
+</table>
+
+#### ℹ️ Examples workflows
+
+[➡️ Available options for this plugin](metadata.yml)
+
+```yaml
+- uses: lowlighter/metrics@latest
+  with:
+    # ... other options
+    plugin_starlists: yes
+    plugin_starlists_limit: 16             # Limit to 16 entries
+    plugin_starlists_limit_repositories: 2 # Limit to 2 repositories per entries
+    plugin_starlists_ignored: list1, list2 # Ignored lists
+    plugin_starlists_only: list3           # Only display this list
+```

--- a/source/plugins/starlists/index.mjs
+++ b/source/plugins/starlists/index.mjs
@@ -26,7 +26,7 @@ export default async function({login, q, imports, data, account}, {enabled = fal
       repositories:[]
     }))))
     const count = lists.length
-    lists = lists.slice(0, limit).filter(({name}) => (only.includes(name.toLocaleLowerCase()))||(!only.length) && ((!name)||(!ignored.includes(name.toLocaleLowerCase()))))
+    lists = lists.slice(0, limit).filter(({name}) => (only.includes(name.toLocaleLowerCase())) || ((!only.length)&&((!name)||(!ignored.includes(name.toLocaleLowerCase())))))
     console.debug(`metrics/compute/${login}/plugins > starlists > extracted ${lists.length} lists`)
 
     //Fetch star list content

--- a/source/plugins/starlists/index.mjs
+++ b/source/plugins/starlists/index.mjs
@@ -1,0 +1,55 @@
+//Setup
+export default async function({login, q, imports, data, account}, {enabled = false} = {}) {
+  //Plugin execution
+  try {
+    //Check if plugin is enabled and requirements are met
+    if ((!enabled)||(!q.starlists))
+      return null
+
+    //Load inputs
+    let {limit, ignored, only, "limit.repositories":_limit} = imports.metadata.plugins.starlists.inputs({data, account, q})
+
+    //Start puppeteer and navigate to star lists
+    console.debug(`metrics/compute/${login}/plugins > starlists > starting browser`)
+    const browser = await imports.puppeteer.launch()
+    console.debug(`metrics/compute/${login}/plugins > starlists > started ${await browser.version()}`)
+    const page = await browser.newPage()
+
+    //Fetch star lists
+    console.debug(`metrics/compute/${login}/plugins > starlists > fetching lists`)
+    await page.goto(`https://github.com/${login}?tab=stars`)
+    let lists = (await page.evaluate(() => [...document.querySelectorAll("[href^='/stars/lowlighter/lists']")].map(element => ({
+      link:element.href,
+      name:element.querySelector("h3")?.innerText ?? "",
+      description:element.querySelector("span")?.innerText ?? "",
+      count:Number(element.querySelector("div")?.innerText.match(/(?<count>\d+)/)?.groups.count),
+      repositories:[]
+    }))))
+    const count = lists.length
+    lists = lists.slice(0, limit).filter(({name}) => (only.includes(name.toLocaleLowerCase()))||(!only.length) && ((!name)||(!ignored.includes(name.toLocaleLowerCase()))))
+    console.debug(`metrics/compute/${login}/plugins > starlists > extracted ${lists.length} lists`)
+
+    //Fetch star list content
+    for (const list of lists) {
+      console.debug(`metrics/compute/${login}/plugins > starlists > fetching ${list.name}`)
+      await page.goto(list.link)
+      const repositories = await page.evaluate(() => [...document.querySelectorAll("#user-list-repositories > div")].map(element => ({
+        name:element.querySelector("div:first-child")?.innerText.replace(" / ", "/") ?? "",
+        description:element.querySelector(".py-1")?.innerText ?? ""
+      })))
+      list.repositories.push(...repositories)
+      list.repositories = list.repositories.slice(0, _limit)
+    }
+
+    //Close browser
+    console.debug(`metrics/compute/${login}/plugins > starlists > closing browser`)
+    await browser.close()
+
+    //Results
+    return {lists, count}
+  }
+  //Handle errors
+  catch (error) {
+    throw {error:{message:"An error occured", instance:error}}
+  }
+}

--- a/source/plugins/starlists/metadata.yml
+++ b/source/plugins/starlists/metadata.yml
@@ -1,0 +1,46 @@
+name: "💫 Starlists"
+category: github
+index: ~
+supports:
+  - user
+scopes: []
+inputs:
+
+  # Enable or disable plugin
+  plugin_starlists:
+    description: Display star lists
+    type: boolean
+    default: no
+
+  # Number of star lists to display
+  plugin_starlists_limit:
+    description: Number of star lists to display
+    type: number
+    default: 2
+    min: 1
+    max: 100
+
+  # Number of repositories to display per star lists
+  plugin_starlists_limit_repositories:
+    description: Number of repositories to display per star lists
+    type: number
+    default: 2
+    min: 0
+    max: 100
+
+  # List of star lists that will be ignored
+  plugin_starlists_ignored:
+    description: Star lists to skip
+    type: array
+    format: comma-separated
+    default: ""
+    example: 😎 list1, 🥳 list2, ...
+
+  # List of star lists to display
+  # Using this option is equivalent of using "plugin_starlists_ignored" with all star lists but the ones listed
+  plugin_starlists_only:
+    description: Start lists to display
+    type: array
+    format: comma-separated
+    default: ""
+    example: 😎 list1, 🥳 list2, ...

--- a/source/plugins/starlists/tests.yml
+++ b/source/plugins/starlists/tests.yml
@@ -1,0 +1,5 @@
+- name: Starlists plugin (default)
+  uses: lowlighter/metrics@latest
+  with:
+    token: MOCKED_TOKEN
+    plugin_starlists: yes

--- a/source/templates/classic/partials/_.json
+++ b/source/templates/classic/partials/_.json
@@ -20,6 +20,7 @@
   "tweets",
   "isocalendar",
   "stars",
+  "starlists",
   "stargazers",
   "people",
   "activity",

--- a/source/templates/classic/partials/starlists.ejs
+++ b/source/templates/classic/partials/starlists.ejs
@@ -1,0 +1,47 @@
+<% if (plugins.starlists) { %>
+  <section>
+    <h2 class="field">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.75 2.5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5zm4 5a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5zm0 5a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5zM3 8a1 1 0 11-2 0 1 1 0 012 0zm-1 6a1 1 0 100-2 1 1 0 000 2z"></path><path d="M13.314 4.918L11.07 2.417A.25.25 0 0111.256 2h4.488a.25.25 0 01.186.417l-2.244 2.5a.25.25 0 01-.372 0z"></path></svg>
+      <%= plugins.starlists?.count ?? "" %> Star list<%= s(plugins.starlists?.count ?? 0) %>
+    </h2>
+    <div class="row">
+      <section class="largeable-flex-wrap">
+        <% if (plugins.starlists.error) { %>
+          <div class="field error">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.343 13.657A8 8 0 1113.657 2.343 8 8 0 012.343 13.657zM6.03 4.97a.75.75 0 00-1.06 1.06L6.94 8 4.97 9.97a.75.75 0 101.06 1.06L8 9.06l1.97 1.97a.75.75 0 101.06-1.06L9.06 8l1.97-1.97a.75.75 0 10-1.06-1.06L8 6.94 6.03 4.97z"></path></svg>
+            <%= plugins.starlists.error.message %>
+          </div>
+        <% } else { %>
+          <% for (const {name, description, count, repositories} of plugins.starlists.lists) { %>
+            <div class="starlist">
+              <h2 class="field">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 4a1 1 0 100-2 1 1 0 000 2zm3.75-1.5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zm0 5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zm0 5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zM3 8a1 1 0 11-2 0 1 1 0 012 0zm-1 6a1 1 0 100-2 1 1 0 000 2z"></path></svg>
+                <%= name %>
+              </h2>
+              <div class="count"><%= count %> repositor<%= s(count, "y") %></div>
+              <div class="description"><%= description %></div>
+              <div class="repositories">
+                <% for (const repository of repositories) { %>
+                  <div class="row fill-width largeable-width-half">
+                    <section class="repository">
+                      <div class="field">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M4 5.75C4 4.784 4.784 4 5.75 4h4.5c.966 0 1.75.784 1.75 1.75v4.5A1.75 1.75 0 0110.25 12h-4.5A1.75 1.75 0 014 10.25v-4.5zm1.75-.25a.25.25 0 00-.25.25v4.5c0 .138.112.25.25.25h4.5a.25.25 0 00.25-.25v-4.5a.25.25 0 00-.25-.25h-4.5z"></path></svg>
+                        <div class="name">
+                          <span><%= repository.name %></span>
+                          <span></span>
+                        </div>
+                      </div>
+                      <div class="field description">
+                        <%= repository.description %>
+                      </div>
+                    </section>
+                  </div>
+                <% } %>
+              </div>
+            </div>
+          <% } %>
+        <% } %>
+      </section>
+    </div>
+  </section>
+<% } %>

--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -837,6 +837,31 @@
     -webkit-box-orient: vertical;
   }
 
+/* Star lists */
+  .starlist {
+    margin-left: 28px;
+  }
+  .starlist > .description, .starlist > .count {
+    margin-left: 32px;
+  }
+  .starlist > .count {
+    font-size: 12px;
+    color: #666666;
+  }
+  .starlist .repositories {
+    margin-left: -5px;
+    margin-bottom: 20px;
+  }
+  .starlist .repository {
+    margin: 6px 0 0;
+  }
+  .starlist .repository .description {
+    font-size: 11px;
+  }
+  .starlist .repository .name {
+    font-size: 14px;
+  }
+
 /* Anilist */
   .anilist {
     display: flex;


### PR DESCRIPTION
Add support for GitHub stars lists

<img src="https://user-images.githubusercontent.com/22963968/149260196-9b6eccf9-3b66-4cd5-94ca-75eac1d83680.png" width="400">

As this GitHub feature is currently in beta and no API is available yet (see https://github.com/github/feedback/discussions/8293), additional complex features for this plugin may be postponed until the release (as puppeteer is the least stable plugin type)

Semi-related: #712