### PR TITLE
fix(plugins/activity): ellipsis for long commit messages

### DIFF
--- a/source/templates/classic/partials/activity.ejs
+++ b/source/templates/classic/partials/activity.ejs
@@ -136,8 +136,8 @@
                     <% } %>
                     <% for (const commit of event.commits) { %>
                       <div class="commit">
-                        <span class="sha">#<%= commit.sha %></span>
-                        <span class="message"><%= commit.message %></span>
+                        <div class="sha">#<%= commit.sha %></div>
+                        <div class="message"><%= commit.message %></div>
                       </div>
                     <% } %>
                   </div>

--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -783,8 +783,14 @@
     margin-top: 4px;
   }
 
+  .activity .commit {
+    display: flex;
+    align-items: center;
+  }
+
   .activity .commit .sha {
     font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    margin-right: 4px;
   }
 
   .activity .commit .message {

--- a/source/templates/repository/partials/activity.ejs
+++ b/source/templates/repository/partials/activity.ejs
@@ -136,8 +136,8 @@
                     <% } %>
                     <% for (const commit of event.commits) { %>
                       <div class="commit">
-                        <span class="sha">#<%= commit.sha %></span>
-                        <span class="message"><%= commit.message %></span>
+                        <div class="sha">#<%= commit.sha %></div>
+                        <div class="message"><%= commit.message %></div>
                       </div>
                     <% } %>
                   </div>


### PR DESCRIPTION
Long commit messages should now be cropped gracefully with an ellipsis `...`