### PR TITLE
build: add fonts to dockerfile to support emojis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf fonts-noto-color-emoji fonts-opensymbol libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends \
+  && mkdir -p /usr/local/share/fonts \
+  && cp /usr/share/fonts/truetype/noto/NotoColorEmoji.ttf /usr/local/share/fonts/ \
+  && chmod 644 /usr/local/share/fonts/NotoColorEmoji.ttf \
+  && fc-cache -fv \
   # Install ruby to support github licensed gem
   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
   && gem install licensed \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
-  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends \
+  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf fonts-noto-color-emoji fonts-opensymbol libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends \
   # Install ruby to support github licensed gem
   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
   && gem install licensed \


### PR DESCRIPTION
Seems the docker image is not able to properly catch emojis through puppeteer, this may be due to missing fonts