### PR TITLE
feat(app/metrics): add `extras_js` support

### DIFF
--- a/source/app/metrics/index.mjs
+++ b/source/app/metrics/index.mjs
@@ -24,7 +24,7 @@ export default async function metrics({login, q}, {graphql, rest, plugins, conf,
     //Initialization
     const pending = []
     const {queries} = conf
-    const extras = {css:(conf.settings.extras?.css ?? conf.settings.extras?.default ? q["extras.css"] ?? "" : "")}
+    const extras = {css:(conf.settings.extras?.css ?? conf.settings.extras?.default) ? q["extras.css"] ?? "" : "", js:(conf.settings.extras?.js ?? conf.settings.extras?.default) ? q["extras.js"] ?? "" : ""}
     const data = {q, animated:true, large:false, base:{}, config:{}, errors:[], plugins:{}, computed:{}, extras}
     const imports = {
       plugins:Plugins,
@@ -189,7 +189,7 @@ export default async function metrics({login, q}, {graphql, rest, plugins, conf,
       console.debug(`metrics/compute/${login} > verified SVG, no parsing errors found`)
     }
     //Resizing
-    const {resized, mime} = await imports.svg.resize(rendered, {paddings:q["config.padding"] || conf.settings.padding, convert:convert === "svg" ? null : convert})
+    const {resized, mime} = await imports.svg.resize(rendered, {paddings:q["config.padding"] || conf.settings.padding, convert:convert === "svg" ? null : convert, js:extras.js || null})
     rendered = resized
 
     //Result

--- a/source/app/web/settings.example.json
+++ b/source/app/web/settings.example.json
@@ -28,6 +28,7 @@
   "extras": {
     "default": false,              "//": "Default extras state (advised to let 'false' unless in debug mode)",
     "css": false,                  "//": "Allow use of 'extras.css' option",
+    "js": false,                   "//": "Allow use of 'extras.js' option",
     "features": false,             "//": "Enable extra features (advised to let 'false' on web instances)"
   },
   "plugins.default": false,        "//": "Default plugin state (advised to let 'false' unless in debug mode)",

--- a/source/plugins/core/metadata.yml
+++ b/source/plugins/core/metadata.yml
@@ -175,6 +175,19 @@ inputs:
     type: string
     default: ""
 
+  extras_js:
+    extras: yes
+    description: |
+      Extra JavaScript
+
+      Custom JavaScript that will be executed during puppeteer rendering.
+      Useful to avoid creating a new template just to tweak some content.
+
+      Note that is it executed within puppeteer context and **not** *metrics* context.
+      It is run after transformations and optimizations, but just before resizing.
+    type: string
+    default: ""
+
   config_timezone:
     description: |
       Timezone for dates


### PR DESCRIPTION
Add support for `extras_js` to inject raw js during image rendering in puppeteer context