### PR TITLE
feat(plugins/base): add bulk query and fallback to unit query

### DIFF
--- a/source/plugins/base/queries/organization.x.graphql
+++ b/source/plugins/base/queries/organization.x.graphql
@@ -1,0 +1,20 @@
+query BaseOrganizationX {
+  organization(login: "$login") {
+    packages {
+      totalCount
+    }
+    sponsorshipsAsSponsor {
+      totalCount
+    }
+    sponsorshipsAsMaintainer {
+      totalCount
+    }
+    membersWithRole {
+      totalCount
+    }
+    repositories(last: 0) {
+      totalCount
+      totalDiskUsage
+    }
+  }
+}

--- a/source/plugins/base/queries/user.x.graphql
+++ b/source/plugins/base/queries/user.x.graphql
@@ -1,0 +1,55 @@
+query BaseUserX {
+  user(login: "$login") {
+    packages {
+      totalCount
+    }
+    starredRepositories {
+      totalCount
+    }
+    watching {
+      totalCount
+    }
+    sponsorshipsAsSponsor {
+      totalCount
+    }
+    sponsorshipsAsMaintainer {
+      totalCount
+    }
+    followers {
+      totalCount
+    }
+    following {
+      totalCount
+    }
+    issueComments {
+      totalCount
+    }
+    organizations {
+      totalCount
+    }
+    repositoriesContributedTo(includeUserRepositories: true) {
+      totalCount
+    }
+    repositories(last: 0) {
+      totalCount
+      totalDiskUsage
+    }
+    contributionsCollection {
+      totalRepositoriesWithContributedCommits
+      totalCommitContributions
+      restrictedContributionsCount
+      totalIssueContributions
+      totalPullRequestContributions
+      totalPullRequestReviewContributions
+    }
+    calendar:contributionsCollection(from: "$calendar.from", to: "$calendar.to") {
+      contributionCalendar {
+        weeks {
+          contributionDays {
+            color
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since #598, the base plugin always perform a lot a query even for a single user.
This attempt to use the older method first and fallback to unit query if needed