### PR TITLE
Patch ref/create and ref/delete display

### DIFF
--- a/source/plugins/activity/README.md
+++ b/source/plugins/activity/README.md
@@ -132,8 +132,8 @@
 <li><code>push</code>: Push of commits</li>
 <li><code>issue</code>: Opening/Reopening/Closing of issues</li>
 <li><code>pr</code>: Opening/Closing of pull requests</li>
-<li>`ref/create: Creation of git tags or git branches</li>
-<li>`ref/delete: Deletion of git tags or git branches</li>
+<li><code>ref/create</code>: Creation of git tags or git branches</li>
+<li><code>ref/delete</code>: Deletion of git tags or git branches</li>
 <li><code>release</code>: Publication of new releases</li>
 <li><code>review</code>: Review of pull requests</li>
 <li><code>comment</code>: Comments on commits, issues and pull requests</li>


### PR DESCRIPTION
In the README, ref/create and ref/delete were missing not in correct shaping. <code></code> were missing.

<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->
