### PR TITLE
fix(plugins/music): apple tracklist (external redesign)

### DIFF
--- a/source/plugins/music/index.mjs
+++ b/source/plugins/music/index.mjs
@@ -105,7 +105,7 @@ export default async function({login, imports, data, q, account}, {enabled = fal
           case "apple": {
             //Parse tracklist
             await frame.waitForFunction(() => !!document.querySelector("embed-root").shadowRoot.querySelector(".audio-tracklist"))
-            //Apple music do a lot of lazy-loading preventing the use of networkIdle, but images are lazy-loaded and through picture tag...
+            //Apple music do a lot of lazy-loading preventing the use of networkIdle
             await new Promise(solve => setTimeout(solve, 10*1000))
             tracks = [
               ...await frame.evaluate(() => {
@@ -155,7 +155,7 @@ export default async function({login, imports, data, q, account}, {enabled = fal
         }
         //Close browser
         console.debug(`metrics/compute/${login}/plugins > music > closing browser`)
-        //await browser.close()
+        await browser.close()
         //Format tracks
         if (Array.isArray(tracks)) {
           //Tracks


### PR DESCRIPTION
Seems that apple completly redesigned their embed player using shadow roots and custom elements which broke apple tracklist mode

Because there are a lot of open connection still open, it's not possible to use `networkIdle0` or `networkIdle2`, so I ended up using an arbitrary wait of 10 seconds... but I'm not really satisfied with this because it seems quite wonky. Should solve the issue while searching for a better solution I guess