### PR TITLE
chore: prepare release v3.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.22.0-beta",
+  "version": "3.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.22.0-beta",
+      "version": "3.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.22.0-beta",
+  "version": "3.22.0",
   "description": "An infographics generator with 30+ plugins and 200+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## 📦 New features

* **🈷️ Most used languages**
  * Verified commits with attached user's gpg keys is now displayed for `indepth` mode #911
* **⏰ WakaTime plugin**
  * Add `plugin_wakatime_languages_other` to include other languages stats (#928 @renbaoshuo)
* **👨‍💻 Lines of code changed**
  * Changed lines will now be counted towards both added/removed lines #936
* **💡 Coding habits**
  * Add `plugin_habits_charts_type` to switch to `chartist` graphs #938
  * <img src="https://user-images.githubusercontent.com/22963968/159414228-a774fa36-d2c3-4d0a-903f-7f1669ef1e02.png" width="320">
* **💕 GitHub Sponsors**
  * Add `plugin_sponsors_past` to display past sponsorships #958
  * <img src="https://user-images.githubusercontent.com/22963968/159411471-b5a1e088-b069-4fb7-9947-da09d7afff8e.png" width="320">
* **🧑‍🤝‍🧑 People plugin**
  * Add `plugin_people_identicons_hide` to mask user without a custom profile picture #967

## 🧰 Fixes and documentation

* **fix(plugins/pagespeed)**: improve error message on http 429
* **fix(app/action)**: avoid dying when formats is not defined
* **fix(plugins/music)**: ellipsis for long track name/artist
* **fix(plugins/achievements)**: update icon to octicon trophy
* **fix(plugins/code)**: increase `plugin_code_load` default to 400
* **fix(plugins/code)**: fix indent remover to keep `\n`
* **fix(plugins/languages)**: number of commits verified appears twice
* **fix(plugins/starlists)**: always return 0 lists
* **fix(plugins/music)**: apple tracklist mode
* **fix(plugins/stargazers)**: missing values for repository template
* **fix(plugins/people)**: duplicate sponsors when using `plugin_people_sponsors_custom`
* **fix(plugins/skyline)**: fix waiting selector 

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/metrics/examples/metrics.sponsors.svg">

<details><summary><a href="https://github.com/sponsors/lowlighter"><code>♥️ Become a sponsor</code></a></summary>

> *project maintained by @lowlighter*

</details>