### PR TITLE
feat(plugins/languages): various improvements

### DIFF
--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -12,12 +12,12 @@ export default async function({login, data, imports, q, rest, account}, {enabled
     //Context
     let context = {mode:"user"}
     if (q.repo) {
-      console.debug(`metrics/compute/${login}/plugins > activity > switched to repository mode`)
+      console.debug(`metrics/compute/${login}/plugins > languages > switched to repository mode`)
       context = {...context, mode:"repository"}
     }
 
     //Load inputs
-    let {ignored, skipped, colors, aliases, details, threshold, limit, indepth, "analysis.timeout":timeout, sections, categories, "recent.categories":_recent_categories, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({
+    let {ignored, skipped, other, colors, aliases, details, threshold, limit, indepth, "analysis.timeout":timeout, sections, categories, "recent.categories":_recent_categories, "recent.load":_recent_load, "recent.days":_recent_days} = imports.metadata.plugins.languages.inputs({
       data,
       account,
       q,
@@ -102,7 +102,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
           const existingColors = languages.colors
           Object.assign(languages, await indepth_analyzer({login, data, imports, repositories, gpg}, {skipped, categories, timeout}))
           Object.assign(languages.colors, existingColors)
-          console.debug(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed} commits`)
+          console.debug(`metrics/compute/${login}/plugins > languages > indepth analysis missed ${languages.missed.commits} commits`)
         }
         catch (error) {
           console.debug(`metrics/compute/${login}/plugins > languages > ${error}`)
@@ -125,10 +125,19 @@ export default async function({login, data, imports, q, rest, account}, {enabled
     }
 
     //Compute languages stats
-    for (const {section, stats = {}, lines = {}, total = 0} of [{section:"favorites", stats:languages.stats, lines:languages.lines, total:languages.total}, {section:"recent", ...languages["stats.recent"]}]) {
+    for (const {section, stats = {}, lines = {}, missed = {bytes:0}, total = 0} of [{section:"favorites", stats:languages.stats, lines:languages.lines, total:languages.total, missed:languages.missed}, {section:"recent", ...languages["stats.recent"]}]) {
       console.debug(`metrics/compute/${login}/plugins > languages > computing stats ${section}`)
-      languages[section] = Object.entries(stats).filter(([name]) => !ignored.includes(name.toLocaleLowerCase())).sort(([_an, a], [_bn, b]) => b - a).slice(0, limit).map(([name, value]) => ({name, value, size:value, color:languages.colors[name], x:0})).filter(({value}) => value / total > threshold
-      )
+      languages[section] = Object.entries(stats).filter(([name]) => !ignored.includes(name.toLocaleLowerCase())).sort(([_an, a], [_bn, b]) => b - a).slice(0, limit).map(([name, value]) => ({name, value, size:value, color:languages.colors[name], x:0})).filter(({value}) => value / total > threshold)
+      if (other) {
+        let value = indepth ? missed.bytes : Object.entries(stats).filter(([name]) => !Object.values(languages[section]).map(({name}) => name).includes(name)).reduce((a, [_, b]) => a + b, 0)
+        if (value) {
+          if (languages[section].length === limit) {
+            const {size} = languages[section].pop()
+            value += size
+          }
+          languages[section].push({name:"Other", value, size:value, get lines() { return missed.lines }, set lines(_) { }, x:0}) //eslint-disable-line brace-style, no-empty-function, max-statements-per-line
+        }
+      }
       const visible = {total:Object.values(languages[section]).map(({size}) => size).reduce((a, b) => a + b, 0)}
       for (let i = 0; i < languages[section].length; i++) {
         const {name} = languages[section][i]

--- a/source/plugins/languages/index.mjs
+++ b/source/plugins/languages/index.mjs
@@ -135,6 +135,7 @@ export default async function({login, data, imports, q, rest, account}, {enabled
             const {size} = languages[section].pop()
             value += size
           }
+          //dprint-ignore-next-line
           languages[section].push({name:"Other", value, size:value, get lines() { return missed.lines }, set lines(_) { }, x:0}) //eslint-disable-line brace-style, no-empty-function, max-statements-per-line
         }
       }

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -50,11 +50,10 @@ inputs:
 
   plugin_languages_other:
     description: |
-      Group unknown and ignored languages into an "Other" category
+      Group unknown, ignored and over-limit languages into a single "Other" category
 
-      If this category is empty, it will be hidden automatically.
-      If not and `plugin_languages_limit` is set, it will count towards languages limit.
-      This option is not subject to `plugin_languages_threshold`.
+      If this option is enabled, "Other" category will not be subject to `plugin_languages_threshold`.
+      It will be automatically hidden if empty.
     type: boolean
     default: no
 

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -48,6 +48,16 @@ inputs:
     type: string
     default: 0%
 
+  plugin_languages_other:
+    description: |
+      Group unknown and ignored languages into an "Other" category
+
+      If this category is empty, it will be hidden automatically.
+      If not and `plugin_languages_limit` is set, it will count towards languages limit.
+      This option is not subject to `plugin_languages_threshold`.
+    type: boolean
+    default: no
+
   plugin_languages_colors:
     description: Custom languages colors
     type: array

--- a/source/templates/classic/partials/languages.ejs
+++ b/source/templates/classic/partials/languages.ejs
@@ -20,22 +20,32 @@
       <% } else { const width = 460 * (1 + large) %>
         <% if (section === "recently-used") { %>
           <small>
-            estimation from <%= plugins.languages["stats.recent"]?.files %> edited file<%= s(plugins.languages["stats.recent"]?.files) %> from <%= plugins.languages["stats.recent"]?.commits %> commit<%= s(plugins.languages["stats.recent"]?.commits) %> over last <%= plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days %> day<%= s(plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days) %>
+            <% if (languages.length) { %>
+              estimation from <%= f(plugins.languages["stats.recent"]?.total) %>b of code in <%= plugins.languages["stats.recent"]?.files %> edited file<%= s(plugins.languages["stats.recent"]?.files) %> across <%= plugins.languages["stats.recent"]?.commits %> commit<%= s(plugins.languages["stats.recent"]?.commits) %> over last <%= plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days %> day<%= s(plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days) %>
+            <% } else { %>
+              No recent push activity found over last <%= plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days %> day<%= s(plugins.languages["stats.recent"]?.latest ?? plugins.languages["stats.recent"]?.days) %>
+            <% } %>
           </small>
         <% } else if ((section === "most-used")&&(plugins.languages.indepth)) { %>
           <small>
-            estimation from <%= plugins.languages.files %> edited file<%= s(plugins.languages.files) %> from <%= plugins.languages.commits %> commit<%= s(plugins.languages.commits) %>
+            <% if (languages.length) { %>
+              estimation from <%= f(plugins.languages.total) %>b of code in <%= plugins.languages.files %> edited file<%= s(plugins.languages.files) %> across <%= plugins.languages.commits %> commit<%= s(plugins.languages.commits) %>
+            <% } else { %>
+              No push activity found
+            <% } %>
           </small>
         <% } %>
-        <svg class="bar" xmlns="http://www.w3.org/2000/svg" width="<%= width %>" height="8">
-          <mask id="languages-bar">
-            <rect x="0" y="0" width="<%= width %>" height="8" fill="white" rx="5"/>
-          </mask>
-          <rect mask="url(#languages-bar)" x="0" y="0" width="<%= languages.length ? 0 : width %>" height="8" fill="#d1d5da"/>
-          <% for (const {name, value, color, x} of languages) { %>
-            <rect mask="url(#languages-bar)" x="<%= x*width %>" y="0" width="<%= value*width %>" height="8" fill="<%= color ?? "#959DA5" %>"/>
-          <% } %>
-        </svg>
+        <% if (languages.length) { %>
+          <svg class="bar" xmlns="http://www.w3.org/2000/svg" width="<%= width %>" height="8">
+            <mask id="languages-bar">
+              <rect x="0" y="0" width="<%= width %>" height="8" fill="white" rx="5"/>
+            </mask>
+            <rect mask="url(#languages-bar)" x="0" y="0" width="<%= languages.length ? 0 : width %>" height="8" fill="#d1d5da"/>
+            <% for (const {name, value, color, x} of languages) { %>
+              <rect mask="url(#languages-bar)" x="<%= x*width %>" y="0" width="<%= value*width %>" height="8" fill="<%= color ?? "#959DA5" %>"/>
+            <% } %>
+          </svg>
+        <% } %>
         <% if (plugins.languages.details.length) { const rows = large ? [0, 1, 2, 3] : (plugins.languages.details.length > 2) ? [0] : [0, 1] %>
           <div class="row fill-width">
             <% for (const row of rows) { %>


### PR DESCRIPTION
Relates #857

- Missed lines/bytes/commits are now counted when in `indepth` mode
  - Unknown lines/bytes languages are included in this stat
- Fix un-awaited fs io (possibly related to #873 ?)
  - Ignore resources busy removal error on cleaning
- Add `--no-merge` when iterating over commit history
- Add `plugin_languages_other` option to group missed/unknown/over-limit languages into a single "Other" category at the end
- On empty results, hide empty bar and display an informational message instead

<img src="https://user-images.githubusercontent.com/22963968/162860307-cd939415-0997-4b0d-8163-97d0281566c2.png" width="400">

