### PR TITLE
fix(plugins/notable): improve readability of indepth badges

### DIFF
--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -197,13 +197,12 @@
   }
   .contribution .gauge text {
     fill: currentColor;
-    font-size: 12px;
-    font-size: 15px;
-    letter-spacing: -2px;
+    font-size: 13px;
   }
   .contribution .gauge {
-    margin: 0 4px;
+    margin: 0 6px;
     color: inherit;
+    transform: scale(1.4) translateY(1px);
   }
   .contribution .icon {
     fill: currentColor;


### PR DESCRIPTION
Closes #993

Slightly scale up badges to make them more readable, without deforming too much current style