### PR TITLE
feat(app/action): add `notice_releases` option

### DIFF
--- a/source/app/action/index.mjs
+++ b/source/app/action/index.mjs
@@ -135,6 +135,7 @@ async function retry(func, {retries = 1, delay = 0} = {}) {
       "output.action":_action,
       "output.condition":_output_condition,
       delay,
+      "notice.release":_notice_releases,
       ...config
     } = metadata.plugins.core.inputs.action({core, preset})
     const q = {...query, ...(_repo ? {repo:_repo} : null), template}
@@ -186,6 +187,15 @@ async function retry(func, {retries = 1, delay = 0} = {}) {
     }
     //Extract octokits
     const {graphql, rest} = api
+
+    //Check for new versions
+    if (_notice_releases) {
+      const {data:[{tag_name:tag}]} = await rest.repos.listReleases({owner:"lowlighter", repo:"metrics"})
+      const current = Number(conf.package.version.match(/(\d+\.\d+)/)?.[1] ?? 0)
+      const latest = Number(tag.match(/(\d+\.\d+)/)?.[1] ?? 0)
+      if (latest > current)
+        console.info(`::notice::A new version of metrics (v${latest}) has been released, check it out for even more features!`)
+    }
 
     //GitHub user
     let authenticated
@@ -273,7 +283,6 @@ async function retry(func, {retries = 1, delay = 0} = {}) {
     }
     else if (dryrun)
       info("Dry-run", true)
-
 
     //SVG file
     conf.settings.optimize = optimize

--- a/source/plugins/core/metadata.yml
+++ b/source/plugins/core/metadata.yml
@@ -379,6 +379,11 @@ inputs:
     min: 0
     max: 3600
 
+  notice_releases:
+    description: Notice about new releases of metrics
+    type: boolean
+    default: yes
+
   # ====================================================================================
   # 🚧 Options below are mostly used for testing
 


### PR DESCRIPTION
Add new option to notice about new official releases of metrics