### PR TITLE
chore: prepare release v3.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.23.0-beta",
+  "version": "3.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.23.0-beta",
+      "version": "3.23.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.23.0-beta",
+  "version": "3.23.0",
   "description": "An infographics generator with 30+ plugins and 200+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## 📦 New features

* **🈷️ Most used languages**
  * Add `plugin_languages_other` option to group missed, unknown or over-limit languages into a single "Other" category displayed last (#985)
  * Missed lines, bytes and commits are now counted in `indepth` mode *(unknown languages are included in this statistic)* (#985)
  * <img src="https://user-images.githubusercontent.com/22963968/162860307-cd939415-0997-4b0d-8163-97d0281566c2.png" width="400">
* **💕 GitHub Sponsors**
  * Add support for fetching all sponsorships and past sponsorships events rather than the first 100 (#1003)
  * Sponsorships from organization are now displayed (#1003)
  * Add `list` section to `plugin_sponsors_sections` (#1011)
    * *Note: `goal` section no longer includes `list` section by default, which means that both output display can be toggled independantly* 
    * <img src="https://user-images.githubusercontent.com/22963968/164944061-9b3aeb4f-df0a-484d-937b-f758b9d53f68.png" width="400">
    * <img src="https://user-images.githubusercontent.com/22963968/164952311-ec1b77f7-c52b-4e9d-a0b9-a8403e7febe7.png" width="400">
  * Add `plugin_sponsors_size` to adjust sponsors pictures size (#1012)
  * Active sponsorships now respect privacy level set by sponsor (#1018)
    * *Note: Because of current GitHub API limitations, past sponsorships are currently always publicly visible* 
* **🗓️ Calendar** <sup>✨ new!</sup>
  * Add new plugin calendar to display your contribution calendar across several years! (#1013) 
  * Use `plugin_calendar_limit` to configure how many years to display (#1013)
  * <img src="https://user-images.githubusercontent.com/22963968/164950555-efa089cb-1593-4191-b1e9-8fc2d8d41318.png" width="400">
* **🗃️ Base content**
  * Add `base_indepth` option to spend additional API requests for more accurate stats (#999)
    * *Improved stats includes: total commits, total issues, total pull requests, total pull requests reviews and total repositories contributed to**
* **⚙️ GitHub Action**
  * Logs now display your API quotas before running (#1008) 
    * *Note: if either REST or GraphQL quotas are exceeded, the action will automatically skip run with a warning message* 
    * <img src="https://user-images.githubusercontent.com/22963968/164942947-86ab3077-87dd-4003-968b-ff7922a062b6.png" width="400">
  * Logs now display consumed API requests after running (#1008)
    * *Note: these estimations are only valid if you didn't use your quota for others apps during metrics execution* 
    * <img src="https://user-images.githubusercontent.com/22963968/164942855-19ab73e5-8b7d-41c4-a609-4ebbae8ee792.png" width="400">
  * Add `notice_releases` option to automatically print a notice when a new release of *metrics* is available (#1009)
    * *Note: this option is enabled by default but can be opted-out* 
  * Add `quota_required_rest`, `quota_required_graphql` and `quota_required_search` options to only run action if GitHub API requests quota requirements are met (#1014)
  * Binaries dependencies are now checked prior running the action to ensure self-hosted runner are compatible 

## 🧰 Fixes and documentation

* **fix(plugins/languages)**: empty results will now display an informational message instead of an empty bar (#985)
* **fix(plugins/languages)**: un-awaited fs io and ignore busy resources removal on cleaning (#985)
* **fix(plugins/languages)**: use `--no-merge` option in `indepth` mode (#985)
* **fix(plugins/languages)**: improved timeout messages (#1004)
* **docs**: reference the optional need of `read:packages`
* **fix(plugins/base)**: number of org packages is incorrect (#1005)
  * *Note: to count packages published on ghcr.io, `read:packages` scope is required*
* **fix(plugins/notable)**: improve readability of indepth badges (#1006)
* **docs**: add navigation links
* **fix(app/action)**: add `--rm` to auto-clean docker images
* **docs**: add self-hosted runner setup

## 🎉 Celebrating 3000 users and 15M downloads!

Thanks a lot for your support 🥳 !
Stay tuned for even more features and stats!

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/metrics/examples/metrics.sponsors.svg">

<details><summary><a href="https://github.com/sponsors/lowlighter"><code>♥️ Become a sponsor</code></a></summary>

> *project maintained by @lowlighter*

</details>