### PR TITLE
feat(plugins/calendar): add negative number support for `plugin_calendar_limit`

### DIFF
--- a/source/plugins/calendar/index.mjs
+++ b/source/plugins/calendar/index.mjs
@@ -10,9 +10,9 @@ export default async function({login, q, data, imports, graphql, queries, accoun
     let {limit} = imports.metadata.plugins.calendar.inputs({data, account, q})
 
     //Compute boundaries
+    const registration = new Date(data.user.createdAt)
     const end = new Date().getFullYear()
-    console.log(data.user.createdAt instanceof Date)
-    const start = (limit ? new Date(end - limit + 1, 0) : new Date(data.user.createdAt)).getFullYear()
+    const start = (limit > 0 ? new Date(end - limit + 1, 0) : limit < 0 ? new Date(new Date(registration).setFullYear(registration.getFullYear() + limit)) : registration).getFullYear()
 
     //Load contribution calendar
     console.debug(`metrics/compute/${login}/plugins > calendar > processing years ${start} to ${end}`)

--- a/source/plugins/calendar/metadata.yml
+++ b/source/plugins/calendar/metadata.yml
@@ -17,7 +17,14 @@ inputs:
     default: no
 
   plugin_calendar_limit:
-    description: Years to display
+    description: |
+      Years to display
+
+      This option has different behaviours depending on its value:
+      - `n > 0` will display the last `n` years, relative to current year
+      - `n == 0` will display all years starting from GitHub account registration date
+      - `n < 0` will display all years plus `n` additional years, relative to GitHub account registration date
+        - Use this when there are commits pushed before GitHub registration
     type: number
     default: 1
     zero: disable


### PR DESCRIPTION
Add support for negative numbers so users can display years prior to GitHub registrations