### PR TITLE
fix(plugins/notable): sort contributions by stargazers

### DIFF
--- a/source/plugins/notable/index.mjs
+++ b/source/plugins/notable/index.mjs
@@ -29,7 +29,7 @@ export default async function({login, q, imports, rest, graphql, data, account, 
     }
 
     //Set contributions
-    contributions = (await Promise.all(contributions.map(async ({handle, stars, issues, pulls, avatarUrl, organization}) => ({name: handle.split("/").shift(), handle, stars, issues, pulls, avatar: await imports.imgb64(avatarUrl), organization})))).sort((a, b) => a.name.localeCompare(b.name))
+    contributions = (await Promise.all(contributions.map(async ({handle, stars, issues, pulls, avatarUrl, organization}) => ({name: handle.split("/").shift(), handle, stars, issues, pulls, avatar: await imports.imgb64(avatarUrl), organization}))))
     console.debug(`metrics/compute/${login}/plugins > notable > found ${contributions.length} notable contributions`)
 
     //Extras features


### PR DESCRIPTION
As discussed in #1021 , removing the `.sort()` does the job as results are already sorted by stars (thanks to #293).

The code has been tested with a GitHub Action and here is the resulting Gist [before](https://gist.githubusercontent.com/bokub/a299e5bf8043cf7bc08284f339e52468/raw/50bf8b05032300c56bf0e036519dce9c089438a5/github-metrics.svg) and [after](https://gist.githubusercontent.com/bokub/a299e5bf8043cf7bc08284f339e52468/raw/c68bb95327ea82be2916baade7bb297530852d79/github-metrics.svg) the change.

I checked with the GraphQL explorer and the order is good:

![image](https://user-images.githubusercontent.com/17952318/165450418-325eabc5-7599-4aa0-b1f4-642973f8ee6e.png)
