### PR TITLE
Update X-RapidAPI-Host to yh-finance.p.rapidapi.com

### DIFF
--- a/source/plugins/community/stock/index.mjs
+++ b/source/plugins/community/stock/index.mjs
@@ -16,14 +16,14 @@ export default async function({login, q, imports, data, account}, {enabled = fal
 
     //Query API for company informations
     console.debug(`metrics/compute/${login}/plugins > stock > querying api for company`)
-    const {data: {quoteType: {shortName: company}}} = await imports.axios.get("https://apidojo-yahoo-finance-v1.p.rapidapi.com/stock/v2/get-profile", {
+    const {data: {quoteType: {shortName: company}}} = await imports.axios.get("https://yh-finance.p.rapidapi.com/stock/v2/get-profile", {
       params: {symbol, region: "US"},
       headers: {"x-rapidapi-key": token},
     })
 
     //Query API for sotck charts
     console.debug(`metrics/compute/${login}/plugins > stock > querying api for stock`)
-    const {data: {chart: {result: [{meta, timestamp, indicators: {quote: [{close}]}}]}}} = await imports.axios.get("https://apidojo-yahoo-finance-v1.p.rapidapi.com/stock/v2/get-chart", {
+    const {data: {chart: {result: [{meta, timestamp, indicators: {quote: [{close}]}}]}}} = await imports.axios.get("https://yh-finance.p.rapidapi.com/stock/v2/get-chart", {
       params: {interval, symbol, range: duration, region: "US"},
       headers: {"x-rapidapi-key": token},
     })

--- a/tests/mocks/api/axios/get/yahoo.mjs
+++ b/tests/mocks/api/axios/get/yahoo.mjs
@@ -1,7 +1,7 @@
 /**Mocked data */
 export default function({faker, url, options, login = faker.internet.userName()}) {
   //Wakatime api
-  if (/^https:..apidojo-yahoo-finance-v1.p.rapidapi.com.stock.v2.*$/.test(url)) {
+  if (/^https:..yh-finance.p.rapidapi.com.stock.v2.*$/.test(url)) {
     //Get company profile
     if (/get-profile/.test(url)) {
       console.debug(`metrics/compute/mocks > mocking yahoo finance api result > ${url}`)


### PR DESCRIPTION
As shown in the latest YH Finance API page, the X-RapidAPI-Host has been changed from **apidojo-yahoo-finance-v1.p.rapidapi.com** to **yh-finance.p.rapidapi.com**.  A related discussion can be found in https://github.com/lowlighter/metrics/discussions/931.

Updating obsoleted URL to the new one to avoid 403 error when trying to get the stock chart from this API.

<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->
