### PR TITLE
fix: output of missing dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1192,7 +1192,7 @@ runs:
         cd $METRICS_ACTION_PATH
         for DEPENDENCY in docker jq; do
           if ! which $DEPENDENCY > /dev/null 2>&1; then
-            echo '::error::"$DEPENDENCY" is not installed on current runner but is needed to run metrics'
+            echo "::error::$DEPENDENCY is not installed on current runner but is needed to run metrics"
             MISSING_DEPENDENCIES=1
           fi
         done

--- a/action.yml
+++ b/action.yml
@@ -1192,7 +1192,7 @@ runs:
         cd $METRICS_ACTION_PATH
         for DEPENDENCY in docker jq; do
           if ! which $DEPENDENCY > /dev/null 2>&1; then
-            echo "::error::$DEPENDENCY is not installed on current runner but is needed to run metrics"
+            echo "::error::\"$DEPENDENCY\" is not installed on current runner but is needed to run metrics"
             MISSING_DEPENDENCIES=1
           fi
         done

--- a/action.yml
+++ b/action.yml
@@ -1192,7 +1192,7 @@ runs:
         cd $METRICS_ACTION_PATH
         for DEPENDENCY in docker jq; do
           if ! which $DEPENDENCY > /dev/null 2>&1; then
-            echo "::error::\"$DEPENDENCY\" is not installed on current runner but is needed to run metrics"
+            echo '::error::"$DEPENDENCY" is not installed on current runner but is needed to run metrics'
             MISSING_DEPENDENCIES=1
           fi
         done

--- a/source/app/action/run.sh
+++ b/source/app/action/run.sh
@@ -4,7 +4,7 @@ echo "GitHub action: $METRICS_ACTION ($METRICS_ACTION_PATH)"
 cd $METRICS_ACTION_PATH
 for DEPENDENCY in docker jq; do
   if ! which $DEPENDENCY > /dev/null 2>&1; then
-    echo '::error::"$DEPENDENCY" is not installed on current runner but is needed to run metrics'
+    echo "::error::\"$DEPENDENCY\" is not installed on current runner but is needed to run metrics"
     MISSING_DEPENDENCIES=1
   fi
 done


### PR DESCRIPTION
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->

This PR fixes the dependency check outputs. 

On self hosted runners it seems like, that `jq` is not installed all the time. There is already a dependency check which runs before the main action and checks the runner. Unfortunately, the echo is not printing the name to console because when printing a variable, double quotes are needed.

Screenshot of running self hosted without `jq`:
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/57319535/170481160-e82cc66b-185b-4584-8e24-3e39f980a300.png">

I added the double quotes and escaped the existing ones. 
