### PR TITLE
Remove relative position which is resetting flexbox container position in Safari.

### DIFF
--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -1220,7 +1220,6 @@
     margin-bottom: -50px;
     margin-top: 36px;
     display: none;
-    position: relative;
   }
   .achievement .value {
     margin-left: 46px;


### PR DESCRIPTION
# Issue
Achievement count badge is out of place.
<img width="1080" alt="CleanShot 2022-06-24 at 14 12 08@2x" src="https://user-images.githubusercontent.com/13214144/175668021-d204cfab-1ba2-47b1-98ac-fc834d2d6487.png">

https://bugs.webkit.org/show_bug.cgi?id=241983
Removing the relative position CSS fix the issue on Safari during zooming of SVG as well as in GitHub app markdown view which uses scaled SVG in mobile web view.