### PR TITLE
chore: prepare release v3.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.26.0-beta",
+  "version": "3.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.26.0-beta",
+      "version": "3.26.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -31,7 +31,6 @@
         "marked": "^4.0.17",
         "memory-cache": "^0.2.0",
         "minimatch": "^5.1.0",
-        "node-chartist": "*",
         "node-fetch": "^3.2.6",
         "open-graph-scraper": "^4.11.1",
         "png-js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.26.0-beta",
+  "version": "3.26.0",
   "description": "An infographics generator with 40+ plugins and 200+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
> ℹ️ This release is mostly focused on **Web instances**.
> If you only use *metrics* through GitHub Actions, you can ignore this version. 

> 🎉 Thanks to all [my sponsors](https://github.com/sponsors/lowlighter), [metrics.lecoq.io](https://metrics.lecoq.io) has been migrated on a more powerful server and should be able to handle more requests!  

## 📦 New features

* **🌐 Web instances**
  * Home page has been redesigned to better guide users through the different features of *metrics*
    * `📊 Metrics embed` is now accessible through `/embed/`
      * Action and markdown tabs can now be displayed without entering an username
    * `✨ Metrics insights` is now accessible through `/insights/`
    * Backwards compatibility with previous endpoints has been kept
      * `/:login` and `/:login/:repository` will still generate embed metrics
      * `/about/` will redirect towards `/insights/`
    * <img src="https://user-images.githubusercontent.com/22963968/177683130-df79c639-c712-4080-a87d-47ae534188d4.png" width="300">
  * Add support for new options in `settings.json`
    * `outputs` can be used to restrict which output formats can be used with `config.output`
    * `modes` can be used to separately enable or disable `embed` and `insights` modes
    * `control.token` can be used to configure a token which can be used by external services to perform action on instance
      * `/.control/stop` can be used to stop instance (useful to redeploy or restart it) 
    * Add more granularity to `extras.features` to enable advanced plugin features
      * This is mostly useful  
      * The following permissions are currently supported:
        - `metrics.setup.community.templates`: Allow community templates download
        - `metrics.setup.community.presets`: Allow community presets usage
        - `metrics.api.github.overuse`: Allow GitHub API intensive requests
        - `metrics.cpu.overuse`: Allow CPU intensive requests
        - `metrics.run.tempdir`: Allow access to temporary directory (including I/O)
        - `metrics.run.git`: Allow to run git 
        - `metrics.run.licensed`: Allow to run licensed 
        - `metrics.run.user.cmd`: Allow to run ANY command by user (USE WITH CAUTION! May result in token leaks by malicious users)
        - `metrics.run.puppeteer.scrapping`: Allow to run puppeteer to scrape data
        - `metrics.run.puppeteer.user.css`: Allow to run CSS by user during puppeteer render
        - `metrics.run.puppeteer.user.js`: Allow to run JavaScript by user during puppeteer render
        - `metrics.npm.optional.chartist`: Allow use of chartist 
        - `metrics.npm.optional.gifencoder`: Allow use of gifencoder 
        - `metrics.npm.optional.libxmljs2`: Allow use of libxmljs2 
      * > ⚠️ If you deployed a web server with a previous version, you **may need to reconfigure** `extras.features` with some of the permissions listed above to keep some plugins working
      * The following settings has been deprecated:
        - `extras.presets` should now use `extras.features` with `metrics.setup.community.presets`
        - `extras.js` should now use `extras.features` with `metrics.run.puppeteer.user.js`
        - `extras.css` should now use `extras.features` with `metrics.run.puppeteer.user.css`
    * Settings display on startup has been improved
      * <img src="https://user-images.githubusercontent.com/22963968/177683603-80efc0b8-cebe-44ba-a900-3e3eda331685.png" width="300">

## 🧰 Fixes and documentation

* **fix(app/web)**: force `faker` to be uncached for users who used a previous version of web instance
* **fix(deps)**: [libxmljs2](https://github.com/marudor/libxmljs2) is now an optional dependency
* **docs(plugins,templates)**: clarification, fix typos and style
* **fix(plugins)**: improved error handling and messages

### 🔐 Security fixes

The following editions fix security issues that were reported by dependabot from unmaintained or outdated dependencies: 

* **fix(deps)**: migrated from [jimp](https://github.com/oliver-moran/jimp) to [sharp](https://github.com/lovell/sharp)
* **fix(deps)**: [node-chartist](https://github.com/panosoft/node-chartist) is now an optional dependency
  * ⚠️ This dependency is still subject to [CVE-2021-20066](https://github.com/advisories/GHSA-f4c9-cqv8-9v98), but there are currently no replacement for this one which is why it now requires `metrics.npm.optional.chartist` permissions and is optional

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/metrics/examples/metrics.sponsors.svg">

<details><summary><a href="https://github.com/sponsors/lowlighter"><code>♥️ Become a sponsor</code></a></summary>

> *project maintained by @lowlighter*

</details>