### PR TITLE
chore: prepare release v3.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.27.0-beta",
+  "version": "3.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.27.0-beta",
+      "version": "3.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.27.0-beta",
+  "version": "3.27.0",
   "description": "An infographics generator with 40+ plugins and 200+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
> 📣 You can now use [beta-metrics.lecoq.io](https://beta-metrics.lecoq.io) to test upcoming releases of [metrics.lecoq.io](https://metrics.lecoq.io)! 

> 📣 You can now login through GitHub OAuth on [metrics.lecoq.io](https://metrics.lecoq.io) to use your own read-only token (revokable anytime) and access more API intensive features that aren't enabled on the web instance by default!

## 📦 New features

* **💕 GitHub Sponsors**
  * Add `plugin_sponsors_title` to set a custom sponsors section title (#1128, @Lissy93)
* **💡 Coding habits** 
  * Add `plugin_habits_languages_threshold` to hide languages below a certain usage threshold (#1138)
* **✨ Stargazers**
  * *(This plugin was renamed from "Stargazers over last weeks" to "Stargazers" in the documentation)*
  * Add `plugin_stargazers_worldmap` to display a worldmap of stargazers's origins! (#1137)
    * Add `plugin_stargazers_charts` to toggle charts display
    * Add `plugin_stargazers_worldmap_token` to set Google Maps Geocoding API
      * *(other Geocoding services may be supported at a later date #1162)*
    * Add `plugin_stargazers_worldmap_sample` to set how many stargazers should be sampled
    * <img src="https://user-images.githubusercontent.com/22963968/179889075-6fc228fb-dbd2-4646-afe6-d5c979af920c.png" width="400">
* **🌇 GitHub Skyline 3D calendar**
  * Add `plugin_skyline_settings` to support alternate skylines, like [Github City](https://github.com/honzaap/GithubCity) (#1139)
    * <img src="https://user-images.githubusercontent.com/22963968/180118751-060861c9-da04-4fba-a1c7-41665d816c99.png" width="400"> 
    * *(Interested in switching from GitHub Skyline to GitHub City ? See [documentation examples](https://github.com/lowlighter/metrics/blob/master/source/plugins/skyline/README.md#%E2%84%B9%EF%B8%8F-examples-workflows) !)* 
* **👨‍💻 Lines of code changed**
  * Add `plugin_lines_sections` to choose whether to display a single line in `base` plugin, or display `repositories` with most lines added/removed, or a diff `history`
  * Add `plugin_lines_repositories_limit` to limit displayed repositories for `repositories` section
  * Add `plugin_lines_history_limit` to limit the number of years displayed by diff `history` graph
  * <img width="400" src="https://user-images.githubusercontent.com/22963968/180591333-80248ebe-ae06-4822-8791-bd8937ea0f7d.png">
* **🗂️ GitHub projects**
  * Add basic support for [GitHub Projects (beta)](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects)
  * <img src="https://user-images.githubusercontent.com/22963968/183258119-8c47ef15-c180-4f95-872f-44ec591fcf14.png" width="400">
* **📓 Featured repositories**
  * Add `plugin_repositories_starred` to display your most starred repositories #1179
  * Add `plugin_repositories_random` to randomly display some of your repositories #1179
  * Add `plugin_repositories_order` to choose how to display `featured`, `pinned`, `starred` and `random` repositories #1179
  * Add `plugin_repositories_affiliations` to control which repositories are fetched by `plugin_repositories_starred` and `plugin_repositories_random` #1179
* **🦑 Miscelleanous**
  * Add `github_api_rest` and `github_api_graphql` to allow support of [GitHub enterprises server](https://github.com/enterprise) API endpoints
* **🌐 Web instances**
  * UI changes (#1171)
    * Clicking in the header bar now redirect to web instance root rather than this repository 
    * Display more clearly deprecated plugins, unsupported options and overall plugin options 
    * Display remaining search requests
  * Add support for signing in with GitHub OAuth (#1171)
    * Signing in lets users use their own GitHub token rather than the configured shared token 
      * Users can also customize which scopes they'd like to provide  
    * Additional extras features permissions can be granted to logged users through `conf.settings.extras.logged`
    * <img src="https://user-images.githubusercontent.com/22963968/182285282-d1261b3b-46c0-427f-aba1-1d9cf44cf07b.png" width="400">  
  * New permissions were added for each external API 
    - `metrics.api.music.any`
    - `metrics.api.google.pagespeed`
    - `metrics.api.twitter.tweets`
    - `metrics.api.yahoo.finance`
  * New permission added for D3 support
    - `metrics.npm.optional.d3`
  * > ⚠️ If you deployed a web server with a previous version, you **may need to reconfigure** `extras.features` with some of the permissions listed above to keep some plugins working 


## 🧰 Fixes and documentation

**fix(app/web)**: lookbehind replace to support Safari for metrics insights
**fix(app)**: allow missing setting 'includes' (#1156, @jayvdb)
**fix(docs)**: expandable json default option value
**fix(docs)**: all plugins now display a non-affiliation disclaimer in their documentation
**fix(app/web)**: improved 404 error handling due to collision with `:login` and `:login/:repository` routes
**fix(docs)**: lot of misspelling (#1180, @jsoref)
**fix(plugins/wakatime)**: `plugin_wakatime_days` not correctly supported

## 🪦 Deprecations

[💭 GitHub Community Support <sub>`support`</sub>](/source/plugins/support/README.md) has been deprecated since the platform has been decomissioned and migrated to [GitHub Discussions](https://github.blog/2022-07-26-launching-github-community-powered-by-github-discussions)

## 🎉 Celebrating 8000 stars!

Thanks a lot for support 🥳 !
Stay tuned for even more features and stats!

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/metrics/examples/metrics.sponsors.svg">

<details><summary><a href="https://github.com/sponsors/lowlighter"><code>♥️ Become a sponsor</code></a></summary>

> *project maintained by @lowlighter*

</details>
