### PR TITLE
feat(plugins/repositories): add `plugin_repositories_forks` option

### DIFF
--- a/source/app/metrics/metadata.mjs
+++ b/source/app/metrics/metadata.mjs
@@ -139,7 +139,7 @@ metadata.plugin = async function({__plugins, __templates, name, logger}) {
             //Format value
             (defaulted => {
               //Default value
-              let value = q[metadata.to.query(key)] ?? q[key] ?? defaulted
+              let value = (meta.category !== "core" ? q[`plugin.${metadata.to.query(key)}`] : null) ?? q[metadata.to.query(key)] ?? q[key] ?? defaulted
               //Apply type conversion
               switch (type) {
                 //Booleans

--- a/source/plugins/repositories/index.mjs
+++ b/source/plugins/repositories/index.mjs
@@ -7,8 +7,9 @@ export default async function({login, q, imports, graphql, queries, data, accoun
       return null
 
     //Load inputs
-    let {featured, pinned, starred, random, order, affiliations: _affiliations} = imports.metadata.plugins.repositories.inputs({data, account, q})
+    let {featured, pinned, starred, random, order, affiliations: _affiliations, forks: _forks} = imports.metadata.plugins.repositories.inputs({data, account, q})
     const affiliations = _affiliations?.length ? `ownerAffiliations: [${_affiliations.map(x => x.toLocaleUpperCase()).join(", ")}]` : ""
+    const forks = _forks ? "" : "isFork: false"
 
     //Initialization
     const repositories = {list: []}
@@ -37,7 +38,7 @@ export default async function({login, q, imports, graphql, queries, data, accoun
 
     //Fetch starred repositories
     if (starred) {
-      const {user: {repositories: {nodes}}} = await graphql(queries.repositories.starred({login, limit: Math.min(starred + 10, 100), affiliations}))
+      const {user: {repositories: {nodes}}} = await graphql(queries.repositories.starred({login, limit: Math.min(starred + 10, 100), affiliations, forks}))
       let count = 0
       for (const node of nodes) {
         if (processed.has(node.nameWithOwner))
@@ -53,7 +54,7 @@ export default async function({login, q, imports, graphql, queries, data, accoun
 
     //Fetch random repositories
     if (random) {
-      const {user: {repositories: {nodes}}} = await graphql(queries.repositories.random({login, affiliations}))
+      const {user: {repositories: {nodes}}} = await graphql(queries.repositories.random({login, affiliations, forks}))
       let count = 0
       for (const node of imports.shuffle(nodes)) {
         if (processed.has(node.nameWithOwner))

--- a/source/plugins/repositories/metadata.yml
+++ b/source/plugins/repositories/metadata.yml
@@ -69,6 +69,12 @@ inputs:
       - random
     default: featured, pinned, starred, random
 
+  plugin_repositories_forks:
+    description: |
+      Include repositories forks
+    type: boolean
+    default: no
+
   plugin_repositories_affiliations:
     description: |
       Repositories affiliations

--- a/source/plugins/repositories/queries/random.graphql
+++ b/source/plugins/repositories/queries/random.graphql
@@ -5,6 +5,7 @@ query RepositoriesRandom {
       first: 100
       privacy: PUBLIC
       $affiliations
+      $forks
     ) {
       nodes {
         nameWithOwner

--- a/source/plugins/repositories/queries/starred.graphql
+++ b/source/plugins/repositories/queries/starred.graphql
@@ -5,6 +5,7 @@ query RepositoriesStarred {
       first: $limit
       privacy: PUBLIC
       $affiliations
+      $forks
     ) {
       nodes {
         nameWithOwner


### PR DESCRIPTION
Closes #1203

Also support `plugin.` prefixed syntax for web instance in case of name collision in options 