### PR TITLE
feat(plugins/starlists): add `ignored` and `aliases` for `starlists.languages` and some fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Generate metrics that can be embedded everywhere, including your GitHub profile 
   </tr>
   <tr>
     <th colspan="2" align="center">
-      <h3><a href="/README.md#-plugins">🧩 Customizable with 42 plugins and 296 options!</a></h3>
+      <h3><a href="/README.md#-plugins">🧩 Customizable with 42 plugins and 298 options!</a></h3>
     </th>
   </tr>
   <tr>

--- a/action.yml
+++ b/action.yml
@@ -710,6 +710,14 @@ inputs:
     description: Display limit (languages per star list)
     default: <default-value>
 
+  plugin_starlists_languages_ignored:
+    description: Ignored languages in star lists
+    default: <default-value>
+
+  plugin_starlists_languages_aliases:
+    description: Custom languages names in star lists
+    default: <default-value>
+
   plugin_starlists_shuffle_repositories:
     description: Shuffle data
     default: <default-value>

--- a/source/plugins/base/README.md
+++ b/source/plugins/base/README.md
@@ -97,8 +97,7 @@ Only use this option when using a plugin that can be configured with <code>token
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>boolean</code>
+    <td nowrap="nowrap"><b>type:</b> <code>boolean</code>
 <br>
 <b>default:</b> no<br></td>
   </tr>

--- a/source/plugins/community/chess/README.md
+++ b/source/plugins/community/chess/README.md
@@ -40,8 +40,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>boolean</code>
+    <td nowrap="nowrap"><b>type:</b> <code>boolean</code>
 <br>
 <b>default:</b> no<br></td>
   </tr>
@@ -52,7 +51,6 @@ All product and company names are trademarks™ or registered® trademarks of th
   </tr>
   <tr>
     <td nowrap="nowrap">🔐 Token<br>
-✨ On <code>master</code>/<code>main</code><br>
 🌐 Web instances must configure <code>settings.json</code>:
 <ul>
 <li><i>metrics.api.chess.any</i></li>
@@ -67,7 +65,6 @@ All product and company names are trademarks™ or registered® trademarks of th
   </tr>
   <tr>
     <td nowrap="nowrap">⏯️ Cannot be preset<br>
-✨ On <code>master</code>/<code>main</code><br>
 <b>type:</b> <code>string</code>
 <br>
 <b>default:</b> <code>→ User login</code><br></td>
@@ -78,8 +75,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>string</code>
+    <td nowrap="nowrap"><b>type:</b> <code>string</code>
 <br>
 <b>allowed values:</b><ul><li>lichess.org</li></ul></td>
   </tr>
@@ -94,8 +90,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>json</code>
+    <td nowrap="nowrap"><b>type:</b> <code>json</code>
 <br>
 <b>default:</b> <details><summary>→ Click to expand</summary><pre language="json"><code>{
   "size": 40,

--- a/source/plugins/habits/README.md
+++ b/source/plugins/habits/README.md
@@ -65,7 +65,6 @@ All product and company names are trademarks™ or registered® trademarks of th
   </tr>
   <tr>
     <td nowrap="nowrap">⏩ Inherits <code>repositories_skipped</code><br>
-✨ On <code>master</code>/<code>main</code><br>
 <b>type:</b> <code>array</code>
 <i>(comma-separated)</i>
 <br></td>

--- a/source/plugins/languages/README.md
+++ b/source/plugins/languages/README.md
@@ -117,7 +117,6 @@ It will be automatically hidden if empty.</p>
   <tr>
     <td nowrap="nowrap"><h4><code>plugin_languages_aliases</code></h4></td>
     <td rowspan="2"><p>Custom languages names</p>
-<p>Example: <code>javascript:JS, typescript:TS</code></p>
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>

--- a/source/plugins/languages/README.md
+++ b/source/plugins/languages/README.md
@@ -117,6 +117,7 @@ It will be automatically hidden if empty.</p>
   <tr>
     <td nowrap="nowrap"><h4><code>plugin_languages_aliases</code></h4></td>
     <td rowspan="2"><p>Custom languages names</p>
+<p>Example: <code>javascript:JS, typescript:TS</code></p>
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>

--- a/source/plugins/languages/metadata.yml
+++ b/source/plugins/languages/metadata.yml
@@ -76,7 +76,7 @@ inputs:
       Custom languages names
     type: string
     default: ""
-    example: javascript:JS typescript:TS
+    example: javascript:JS, typescript:TS
 
   plugin_languages_sections:
     description: |

--- a/source/plugins/leetcode/README.md
+++ b/source/plugins/leetcode/README.md
@@ -39,8 +39,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>boolean</code>
+    <td nowrap="nowrap"><b>type:</b> <code>boolean</code>
 <br>
 <b>default:</b> no<br></td>
   </tr>
@@ -51,7 +50,6 @@ All product and company names are trademarks™ or registered® trademarks of th
   </tr>
   <tr>
     <td nowrap="nowrap">⏯️ Cannot be preset<br>
-✨ On <code>master</code>/<code>main</code><br>
 <b>type:</b> <code>string</code>
 <br>
 <b>default:</b> <code>→ User login</code><br></td>
@@ -67,8 +65,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>array</code>
+    <td nowrap="nowrap"><b>type:</b> <code>array</code>
 <i>(comma-separated)</i>
 <br>
 <b>default:</b> solved<br>
@@ -80,8 +77,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>number</code>
+    <td nowrap="nowrap"><b>type:</b> <code>number</code>
 <i>(0 ≤
 𝑥)</i>
 <br>
@@ -94,8 +90,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>number</code>
+    <td nowrap="nowrap"><b>type:</b> <code>number</code>
 <i>(1 ≤
 𝑥
 ≤ 15)</i>

--- a/source/plugins/notable/README.md
+++ b/source/plugins/notable/README.md
@@ -133,8 +133,7 @@ Some repositories may not be able to reported advanced stats and in the case the
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>boolean</code>
+    <td nowrap="nowrap"><b>type:</b> <code>boolean</code>
 <br>
 <b>default:</b> no<br></td>
   </tr>

--- a/source/plugins/repositories/README.md
+++ b/source/plugins/repositories/README.md
@@ -117,8 +117,7 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
-<b>type:</b> <code>boolean</code>
+    <td nowrap="nowrap"><b>type:</b> <code>boolean</code>
 <br>
 <b>default:</b> no<br></td>
   </tr>

--- a/source/plugins/starlists/README.md
+++ b/source/plugins/starlists/README.md
@@ -98,6 +98,26 @@ All product and company names are trademarks™ or registered® trademarks of th
 <b>default:</b> 8<br></td>
   </tr>
   <tr>
+    <td nowrap="nowrap"><h4><code>plugin_starlists_languages_ignored</code></h4></td>
+    <td rowspan="2"><p>Ignored languages in star lists</p>
+<img width="900" height="1" alt=""></td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap"><b>type:</b> <code>array</code>
+<i>(comma-separated)</i>
+<br></td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap"><h4><code>plugin_starlists_languages_aliases</code></h4></td>
+    <td rowspan="2"><p>Custom languages names in star lists</p>
+<p>Example: <code>javascript:JS, typescript:TS</code></p>
+<img width="900" height="1" alt=""></td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap"><b>type:</b> <code>string</code>
+<br></td>
+  </tr>
+  <tr>
     <td nowrap="nowrap"><h4><code>plugin_starlists_shuffle_repositories</code></h4></td>
     <td rowspan="2"><p>Shuffle data</p>
 <p>Can be used to create varied outputs</p>

--- a/source/plugins/starlists/README.md
+++ b/source/plugins/starlists/README.md
@@ -103,18 +103,19 @@ All product and company names are trademarks™ or registered® trademarks of th
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap"><b>type:</b> <code>array</code>
+    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
+<b>type:</b> <code>array</code>
 <i>(comma-separated)</i>
 <br></td>
   </tr>
   <tr>
     <td nowrap="nowrap"><h4><code>plugin_starlists_languages_aliases</code></h4></td>
     <td rowspan="2"><p>Custom languages names in star lists</p>
-<p>Example: <code>javascript:JS, typescript:TS</code></p>
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>
-    <td nowrap="nowrap"><b>type:</b> <code>string</code>
+    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
+<b>type:</b> <code>string</code>
 <br></td>
   </tr>
   <tr>

--- a/source/plugins/starlists/index.mjs
+++ b/source/plugins/starlists/index.mjs
@@ -63,7 +63,7 @@ export default async function({login, q, imports, data, account}, {enabled = fal
             }))
           ),
         )
-        if (await page.evaluate(() => document.querySelector(".next_page.disabled"))) {
+        if (!(await page.evaluate(() => document.querySelector(".next_page"))) || await page.evaluate(() => document.querySelector(".next_page.disabled"))) {
           console.debug(`metrics/compute/${login}/plugins > starlists > reached last page`)
           break
         }

--- a/source/plugins/starlists/index.mjs
+++ b/source/plugins/starlists/index.mjs
@@ -77,9 +77,9 @@ export default async function({login, q, imports, data, account}, {enabled = fal
       if (languages) {
         list.languages = {}
         for (const {language: {name, color}} of repositories) {
-          let lang = name;
+          let lang = name
           if (lang && lang.toLocaleLowerCase() in _languages_aliases) {
-            lang = _languages_aliases[name.toLocaleLowerCase()];
+            lang = _languages_aliases[name.toLocaleLowerCase()]
           }
           if (lang)
             list.languages[lang] = (list.languages[lang] ?? 0) + 1

--- a/source/plugins/starlists/index.mjs
+++ b/source/plugins/starlists/index.mjs
@@ -7,9 +7,10 @@ export default async function({login, q, imports, data, account}, {enabled = fal
       return null
 
     //Load inputs
-    let {limit, ignored, only, "limit.repositories": _limit, languages, "limit.languages": _limit_languages, "shuffle.repositories": _shuffle} = imports.metadata.plugins.starlists.inputs({data, account, q})
+    let {limit, ignored, only, "limit.repositories": _limit, languages, "limit.languages": _limit_languages, "languages.ignored": _languages_ignored, "languages.aliases": _languages_aliases, "shuffle.repositories": _shuffle} = imports.metadata.plugins.starlists.inputs({data, account, q})
     ignored = ignored.map(imports.stripemojis)
     only = only.map(imports.stripemojis)
+    _languages_aliases = Object.fromEntries(_languages_aliases.split(",").filter(alias => /^[\s\S]+:[\s\S]+$/.test(alias)).map(alias => alias.trim().split(":")).map(([key, value]) => [key.toLocaleLowerCase(), value]))
 
     //Start puppeteer and navigate to star lists
     console.debug(`metrics/compute/${login}/plugins > starlists > starting browser`)
@@ -76,12 +77,16 @@ export default async function({login, q, imports, data, account}, {enabled = fal
       if (languages) {
         list.languages = {}
         for (const {language: {name, color}} of repositories) {
-          if (name)
-            list.languages[name] = (list.languages[name] ?? 0) + 1
+          let lang = name;
+          if (lang && lang.toLocaleLowerCase() in _languages_aliases) {
+            lang = _languages_aliases[name.toLocaleLowerCase()];
+          }
+          if (lang)
+            list.languages[lang] = (list.languages[lang] ?? 0) + 1
           if (color)
-            colors[name] = color
+            colors[lang] = color
         }
-        list.languages = Object.entries(list.languages).sort((a, b) => b[1] - a[1]).slice(0, _limit_languages || Infinity)
+        list.languages = Object.entries(list.languages).filter(([name]) => !_languages_ignored.includes(name.toLocaleLowerCase())).sort((a, b) => b[1] - a[1]).slice(0, _limit_languages || Infinity)
         const visible = list.languages.map(([_, value]) => value).reduce((a, b) => a + b, 0)
         list.languages = list.languages.map(([name, value]) => ({name, value, color: name in colors ? `#${colors[name]}` : null, x: 0, p: value / visible}))
         for (let i = 1; i < list.languages.length; i++)

--- a/source/plugins/starlists/metadata.yml
+++ b/source/plugins/starlists/metadata.yml
@@ -48,6 +48,21 @@ inputs:
     default: 8
     min: 0
     zero: disable
+  
+  plugin_starlists_languages_ignored:
+    description: |
+      Ignored languages in star lists
+    type: array
+    format: comma-separated
+    default: ""
+    example: html, css, ...
+  
+  plugin_starlists_languages_aliases:
+    description: |
+      Custom languages names in star lists
+    type: string
+    default: ""
+    example: javascript:JS, typescript:TS
 
   plugin_starlists_shuffle_repositories:
     description: |


### PR DESCRIPTION
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->

Implemented the feature in #1223.

## Changes

- one fix in plugins/starlists
    - the loop below will not be broken if the star list has only one page (which means it doesn't have `.next_page` selector). So I added an extra condition for checking whether break the loop. https://github.com/lowlighter/metrics/blob/cf98a50eb63499d520bea42d8129d1cb8682de0f/source/plugins/starlists/index.mjs#L49-L70
- added the feature
    - just same as plugins/languages
    - and I also updated `metadata.yml` and `README.md`
- one docs fix in plugins/languages
    - the example of `plugins_languages_aliases` is wrong (`javascript:JS typescript:TS`), the separator is a comma instead of whitespace. I fixed that and also added this example to `README.md`.

## Test
I have tested the new feature locally using my account and my star lists. It works fine!

**original**:
```text
starlists.languages=1
starlists.limit.repositories=0
starlists.only=Learning,Tools
```
![before](https://user-images.githubusercontent.com/44120331/189415664-600157e2-5068-46a0-b9f9-c4ea268a4dc7.svg)


**with new feature**:
```text
starlists.languages=1
starlists.limit.repositories=0
starlists.only=Learning,Tools
starlists.languages.ignored=html
starlists.languages.aliases=javascript:JS,Jupyter Notebook:ipynb
```
![after](https://user-images.githubusercontent.com/44120331/189415372-ea5fce7d-bf9d-44b2-b062-c16c3d9a36cb.svg)

You can see that `html` has disappeared and `javascript -> JS` `Jupyter Notebook -> ipynb`.
