### PR TITLE
fix: fix bad GitHub Linguist link

### DIFF
--- a/source/app/web/statics/insights/index.html
+++ b/source/app/web/statics/insights/index.html
@@ -314,7 +314,7 @@
                 <p>
                   <b>{{ user }}</b> has used {{ languages.length }} different language{{ format("plural", languages.length) }} for a total of {{ format("number", languages.total) }} byte{{ format("plural", languages.total) }}.
                   <small class="footnote">
-                    Note that these numbers are based on results produced by <a href="github.com/github/linguist">GitHub linguist</a> from repositories owned by <b>{{ user }}</b> and that they may not be entirely accurate.
+                    Note that these numbers are based on results produced by <a href="https://github.com/github/linguist">GitHub linguist</a> from repositories owned by <b>{{ user }}</b> and that they may not be entirely accurate.
                   </small>
                 </p>
                 <div class="list">


### PR DESCRIPTION
This fixes a bad link introduced in #1098

![Discord_1rZYYIiFEY](https://user-images.githubusercontent.com/22679886/199851119-3876b17d-b22d-4fdd-b614-d979fac8c69c.png)
