### PR TITLE
change link from GitHub Linguist to LinguistJS

### DIFF
--- a/source/app/web/statics/insights/index.html
+++ b/source/app/web/statics/insights/index.html
@@ -314,7 +314,7 @@
                 <p>
                   <b>{{ user }}</b> has used {{ languages.length }} different language{{ format("plural", languages.length) }} for a total of {{ format("number", languages.total) }} byte{{ format("plural", languages.total) }}.
                   <small class="footnote">
-                    Note that these numbers are based on results produced by <a href="https://github.com/github/linguist">GitHub linguist</a> from repositories owned by <b>{{ user }}</b> and that they may not be entirely accurate.
+                    Note that these numbers are based on results produced by <a href="https://github.com/Nixinova/LinguistJS">LinguistJS</a> from repositories owned by <b>{{ user }}</b> and may not be entirely accurate.
                   </small>
                 </p>
                 <div class="list">


### PR DESCRIPTION

        Metrics uses LinguistJS now, should this be changed to link to that instead?

_Originally posted by @Nixinova in https://github.com/lowlighter/metrics/pull/1277#discussion_r1015121961_
      
Changes the link from https://github.com/github/linguist to https://github.com/Nixinova/LinguistJS