### PR TITLE
chore: prepare release v3.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "3.30.0-beta",
+  "version": "3.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "3.30.0-beta",
+      "version": "3.30.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "3.30.0-beta",
+  "version": "3.30.0",
   "description": "An infographics generator with 40+ plugins and 300+ options to display stats about your GitHub account and render them as SVG, Markdown, PDF or JSON!",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## 📦 New features

* **🦑 Miscelleanous**
  * The action will throw an error when trying to use [GitHub fine-grained personal access tokens](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/) as `token` as it's not possible to use them to authenticate to GitHub GraphQL API yet
    * *If fine-grained PATs can be used for authenticating to GraphQL API in the future, support for them will be considered* 

### 🎲 Community plugins

* **🦑 Splatoon <sup>✨ new!</sup>**
  - Configure `plugin_splatoon_token` to display your Splatnet 3 data ! (#1287, #1303)
  - Enable `plugin_splatoon_statink` and set `plugin_splatoon_statink_token` for [stat.ink](https://stat.ink/) integration
  - Display your `player` nameplate, last `versus` matches and last `salmon-run` shifts using `plugin_splatoon_sections`  !
    - Use `plugin_splatoon_versus_limit` or `plugin_splatoon_salmon_limit` to configure the number of matches displayed
    - <img src="https://user-images.githubusercontent.com/22963968/204425183-71840cee-8e06-4e44-97d7-e6aef728f739.png" width="400">
* **♟️ Chess**
  - ***fix**: black pawn represented as emoji instead of unicode*
* **📸 Website screenshot**
  - Add `plugin_screenshot_viewport` to configure screenshot viewport (#1288)
  - Add `plugin_screenshot_wait` to delay screenshot (#1288)
  - ***fix**: wait for idle network and dom loaded*


## 🧰 Fixes and documentation

**docs**: improve community plugins
**docs**: improve references
**fix(app/action)**: mishandled `config_output` (#1293, #1295)
**fix(app/web)**: unsupported plugins display notice

## 💕 Sponsors
<img src="https://raw.githubusercontent.com/lowlighter/metrics/examples/metrics.sponsors.svg">

<details><summary><a href="https://github.com/sponsors/lowlighter"><code>♥️ Become a sponsor</code></a></summary>

> *project maintained by @lowlighter*

</details>