### PR TITLE
docs(steam): correct `plugin_steam_user` example

### DIFF
--- a/source/plugins/steam/examples.yml
+++ b/source/plugins/steam/examples.yml
@@ -6,7 +6,7 @@
     base: ""
     plugin_steam_token: ${{ secrets.STEAM_TOKEN }}
     plugin_steam: yes
-    plugin_steam_user: 0
+    plugin_steam_user: "0"
     plugin_steam_sections: recently-played
     plugin_steam_achievements_limit: 0
   prod:
@@ -23,7 +23,7 @@
     base: ""
     plugin_steam_token: ${{ secrets.STEAM_TOKEN }}
     plugin_steam: yes
-    plugin_steam_user: 0
+    plugin_steam_user: "0"
   prod:
     # ⚠️ Using mocked data for privacy reasons
     with:


### PR DESCRIPTION
`""` is necessary for `plugin_steam_user`.

I got this error when it was missing:

![steam-error](https://user-images.githubusercontent.com/25550534/228223729-6948e96f-aeb9-4501-b390-b6722e80485f.png)

Maybe caused by:
```
Steam user id                                                   │ 7.65611984543922E+16
```
https://github.com/CCXXXI/CCXXXI/actions/runs/4542103774/jobs/8005095844#step:2:1053

