### PR TITLE
Grammatical Correction

### DIFF
--- a/source/plugins/support/index.mjs
+++ b/source/plugins/support/index.mjs
@@ -24,7 +24,7 @@ export default async function({login, q, imports, data, account}, {enabled = fal
         await frame.waitForSelector(".user-profile-names", {timeout: 5000})
       }
       catch {
-        throw {error: {message: "Account does not exists on github.community"}}
+        throw {error: {message: "Account does not exist on github.community"}}
       }
     }
 


### PR DESCRIPTION
Changed the github community plugin to use proper grammer. 

Currently says "account does not exists on github.community" if it fails to find the account. Changing to "account does not exist on github.community"