### PR TITLE
fix(achievements): update total data acquisition method

### DIFF
--- a/source/plugins/achievements/index.mjs
+++ b/source/plugins/achievements/index.mjs
@@ -82,13 +82,16 @@ async function total({imports}) {
       //Extracting total from github.com/search
       for (let i = 0; (i < 100) && ((!total.users) || (!total.repositories)); i++) {
         const page = await browser.newPage()
-        await page.goto("https://github.com/search")
-        const result = await page.evaluate(() => [...document.querySelectorAll("h2")].filter(node => /Search more/.test(node.innerText)).shift()?.innerText.trim().match(/(?<count>\d+)M\s+(?<type>repositories|users|issues)$/)?.groups) ?? null
-        console.debug(`metrics/compute/plugins > achievements > setup found ${result?.type ?? "(?)"}`)
-        if ((result?.type) && (!total[result.type])) {
-          const {count, type} = result
-          total[type] = Number(count) * 10e5
-          console.debug(`metrics/compute/plugins > achievements > set total.${type} to ${total[type]}`)
+        await page.goto("https://github.com/search?q=+created%3A%3E2007")
+        const totalres = await page.evaluate(() => [...[...document.querySelectorAll("h2")].filter(node => /Filter by/.test(node.innerText)).shift()?.nextSibling?.innerText.trim().matchAll(/(?<type>Repositories|Users|Issues)\n(?<count>.*?)M/g) ?? []]) ?? null
+        for (const result of totalres) {
+          const type = result[1]?.toLowerCase()
+          console.debug(`metrics/compute/plugins > achievements > setup found ${type ?? "(?)"}`)
+          const count = result[2] ?? ""
+          if ((count !== "") && (!total[type])) {
+            total[type] = Number(count) * 10e5
+            console.debug(`metrics/compute/plugins > achievements > set total.${type} to ${total[type]}`)
+          }
         }
         await page.close()
         await imports.wait(10 * Math.random())

--- a/source/plugins/achievements/index.mjs
+++ b/source/plugins/achievements/index.mjs
@@ -83,8 +83,8 @@ async function total({imports}) {
       for (let i = 0; (i < 100) && ((!total.users) || (!total.repositories)); i++) {
         const page = await browser.newPage()
         await page.goto("https://github.com/search?q=+created%3A%3E2007")
-        const totalres = await page.evaluate(() => [...[...document.querySelectorAll("h2")].filter(node => /Filter by/.test(node.innerText)).shift()?.nextSibling?.innerText.trim().matchAll(/(?<type>Repositories|Users|Issues)\n(?<count>.*?)M/g) ?? []]) ?? null
-        for (const result of totalres) {
+        const results = await page.evaluate(() => [...[...document.querySelectorAll("h2")].filter(node => /Filter by/.test(node.innerText)).shift()?.nextSibling?.innerText.trim().matchAll(/(?<type>Repositories|Users|Issues)\n(?<count>.*?)M/g) ?? []]) ?? null
+        for (const result of results) {
           const type = result[1]?.toLowerCase()
           console.debug(`metrics/compute/plugins > achievements > setup found ${type ?? "(?)"}`)
           const count = result[2] ?? ""


### PR DESCRIPTION
<!--

  👋 Hi there!
  Thanks for contributing to metrics and helping us to improve!

  Please:
    - Read CONTRIBUTING.md first
    - Check you're not duplicating another existing pull request
    - Provide a clear and concise description

  Note that:
    - Your code will be automatically formatted by github-actions
    - Head branches are automatically deleted when merged

-->

See https://github.com/lowlighter/metrics/issues/1479#issuecomment-1633615855. 

GitHub hide the total data from the homepage of GitHub Search. So I get them by searching `create:>2007` (since GitHub is founded in 2008) as a temporary fix.

This may not obtain the accurate data (especially the total number of repos), but at least it works. Maybe using an api provided by GitHub is the best choice, but I didn't find such an api.

Closes #1479.