### PR TITLE
find pre-2007 activity

### DIFF
--- a/source/plugins/achievements/index.mjs
+++ b/source/plugins/achievements/index.mjs
@@ -82,7 +82,7 @@ async function total({imports}) {
       //Extracting total from github.com/search
       for (let i = 0; (i < 100) && ((!total.users) || (!total.repositories)); i++) {
         const page = await browser.newPage()
-        await page.goto("https://github.com/search?q=+created%3A%3E2007")
+        await page.goto("https://github.com/search?q=created%3A%3E%3D1970")
         const results = await page.evaluate(() => [...[...document.querySelectorAll("h2")].filter(node => /Filter by/.test(node.innerText)).shift()?.nextSibling?.innerText.trim().matchAll(/(?<type>Repositories|Users|Issues)\n(?<count>.*?)M/g) ?? []]) ?? null
         for (const result of results) {
           const type = result[1]?.toLowerCase()


### PR DESCRIPTION
#1479 was not fixed by #1487 for me; I have some private pre-2007 content that continued to generate [#1479’s Unexpected error](https://github.com/lowlighter/metrics/issues/1479#issue-1799689722).

The issue is resolved by [`71f6dbd178`](https://github.com/LucasLarson/metrics/commit/71f6dbd1782a86bf3e1e827a6951b2527afc3498), which changes the search scope from
after 2007 (`>2007`) to
during or after the beginning of the Unix epoch (`>=1970`)