### PR TITLE
chess user name included in the plugin example

### DIFF
--- a/source/plugins/community/chess/README.md
+++ b/source/plugins/community/chess/README.md
@@ -127,6 +127,7 @@ with:
   token: NOT_NEEDED
   base: ""
   plugin_chess: yes
+  plugin_chess_user: ${{ secrets.CHESS_USER }}
   plugin_chess_token: ${{ secrets.CHESS_TOKEN }}
   plugin_chess_platform: lichess.org
 


### PR DESCRIPTION
### Description

This PR update includes the addition of the `plugin_chess_user` parameter to specify the Lichess username for which the most recent game should be fetched.

### Changes

- **Added `plugin_chess_user` parameter**: This new parameter allows specifying the Lichess username to fetch the latest game. It uses the value from the repository secrets (`secrets.CHESS_USER`).
- **Configuration Update**: Updated the `metrics.plugin.chess.svg` action configuration to include the new parameter for fetching user-specific data.

### Details

The `plugin_chess_user` parameter was added because the Lichess API endpoint for retrieving the latest game requires a user identifier. This change ensures that the workflow correctly fetches the most recent game for the specified user.

### Example Configuration

```yaml
name: Last chess game from lichess.org
uses: lowlighter/metrics@latest
with:
  filename: metrics.plugin.chess.svg
  token: NOT_NEEDED
  base: ""
  plugin_chess: yes
  plugin_chess_user: ${{ secrets.CHESS_USER }}
  plugin_chess_token: ${{ secrets.CHESS_TOKEN }}
  plugin_chess_platform: lichess.org
```

### Testing

- Ensure that `secrets.CHESS_USER` is set in the repository secrets.
- Verify that the Lichess token (`secrets.CHESS_TOKEN`) has appropriate permissions.
- Run the workflow and confirm that the `metrics.plugin.chess.svg` file is generated correctly with the latest game for the specified user.