### PR TITLE
Add `xz-utils` as dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \


### PR DESCRIPTION
### Description
Fix licensed gem installation failure on ubuntu-latest (probably Ubuntu 24.04) runner. The issue was discovered during recent GitHub Actions ubuntu-latest image upgrade ([announcement](https://github.com/actions/runner-images/issues/10636)), where `nokogiri` compilation fails due to missing `xzcat`.

### Problem
When [running metrics action](https://github.com/MarioZZJ/MarioZZJ/actions/runs/12498018879) on Ubuntu 24.04 (new ubuntu-latest), licensed gem installation failed with:

```
ERROR: Failed to build gem native extension.
...
/var/lib/gems/3.1.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:557:in `xzcat_exe': xzcat not found (RuntimeError)
```

### Solution
Add `xz-utils` package to Dockerfile dependencies to provide `xzcat` command required by `nokogiri` compilation.

### Testing
Successfully tested with action running on ubuntu-latest ([workflow run](https://github.com/MarioZZJ/MarioZZJ/actions/runs/12522359544))

### Notes
Since GitHub's ubuntu-latest upgrade is rolling out until *January 17th, 2025* (see [announcement](https://github.com/actions/runner-images/issues/10636)):
- This PR could be merged after majority of users migrate to Ubuntu 24.04
- Or affected users can temporarily use `runs-on: ubuntu-22.04` as workaround

