### PR TITLE
Fix CI pipeline failure in forked repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && npm run build
 
 # Environment variables
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-ENV PUPPETEER_BROWSER_PATH "google-chrome-stable"
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_BROWSER_PATH="google-chrome-stable"
 
 # Execute GitHub action
 ENTRYPOINT node /metrics/source/app/action/index.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
   && apt-get update \
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils && sudo gem install licensed \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
+  && gem install licensed \
   && apt-get install -y wget gnupg ca-certificates libgconf-2-4 \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
@@ -35,4 +36,4 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_BROWSER_PATH="google-chrome-stable"
 
 # Execute GitHub action
-ENTRYPOINT node /metrics/source/app/action/index.mjs
+ENTRYPOINT ["node", "/metrics/source/app/action/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
   && apt-get update \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils && sudo gem install licensed \
   && apt-get install -y wget gnupg ca-certificates libgconf-2-4 \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
   && apt-get update \
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
-  && gem install licensed \
   && apt-get install -y wget gnupg ca-certificates libgconf-2-4 \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
@@ -21,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \


### PR DESCRIPTION
[https://github.com/ltpp-universe/ltpp-universe/actions/runs/15124919792/job/42515259367](https://github.com/ltpp-universe/ltpp-universe/actions/runs/15124919792/job/42515259367)
```sh
  #9 ERROR: process "/bin/sh -c chmod +x /metrics/source/app/action/index.mjs   && apt-get update   && apt-get install -y wget gnupg ca-certificates libgconf-2-4   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -   && sh -c 'echo \"deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main\" >> /etc/apt/sources.list.d/google.list'   && apt-get update   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends   && apt-get install -y curl unzip   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev   && gem install licensed   && apt-get install -y python3   && rm -rf /var/lib/apt/lists/*   && npm ci   && npm run build" did not complete successfully: exit code: 1
  ------
   > [4/4] RUN chmod +x /metrics/source/app/action/index.mjs   && apt-get update   && apt-get install -y wget gnupg ca-certificates libgconf-2-4   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'   && apt-get update   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends   && apt-get install -y curl unzip   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev   && gem install licensed   && apt-get install -y python3   && rm -rf /var/lib/apt/lists/*   && npm ci   && npm run build:
  43.88 	from extconf.rb:892:in `<main>'
  43.88 
  43.88 To see why this extension failed to compile, please check the mkmf.log which can be found here:
  43.88 
  43.88   /var/lib/gems/3.1.0/extensions/x86_64-linux/3.1.0/nokogiri-1.18.8/mkmf.log
  43.88 
  43.88 extconf failed, exit code 1
  43.88 
  43.88 Gem files will remain installed in /var/lib/gems/3.1.0/gems/nokogiri-1.18.8 for inspection.
  43.88 Results logged to /var/lib/gems/3.1.0/extensions/x86_64-linux/3.1.0/nokogiri-1.18.8/gem_make.out
  ------
  
   3 warnings found (use docker --debug to expand):
   - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 33)
   - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 34)
   - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 37)
  Dockerfile:9
  --------------------
     8 |     # Setup
     9 | >>> RUN chmod +x /metrics/source/app/action/index.mjs \
    10 | >>>   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
    11 | >>>   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
    12 | >>>   && apt-get update \
    13 | >>>   && apt-get install -y wget gnupg ca-certificates libgconf-2-4 \
    14 | >>>   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
    15 | >>>   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
    16 | >>>   && apt-get update \
    17 | >>>   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends \
    18 | >>>   # Install deno for miscellaneous scripts
    19 | >>>   && apt-get install -y curl unzip \
    20 | >>>   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
    21 | >>>   # Install ruby to support github licensed gem
    22 | >>>   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
    23 | >>>   && gem install licensed \
    24 | >>>   # Install python for node-gyp
    25 | >>>   && apt-get install -y python3 \
    26 | >>>   # Clean apt/lists
    27 | >>>   && rm -rf /var/lib/apt/lists/* \
    28 | >>>   # Install node modules and rebuild indexes
    29 | >>>   && npm ci \
    30 | >>>   && npm run build
    31 |     
  --------------------
  ERROR: failed to solve: process "/bin/sh -c chmod +x /metrics/source/app/action/index.mjs   && apt-get update   && apt-get install -y wget gnupg ca-certificates libgconf-2-4   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -   && sh -c 'echo \"deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main\" >> /etc/apt/sources.list.d/google.list'   && apt-get update   && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libx11-xcb1 libxtst6 lsb-release --no-install-recommends   && apt-get install -y curl unzip   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh   && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev   && gem install licensed   && apt-get install -y python3   && rm -rf /var/lib/apt/lists/*   && npm ci   && npm run build" did not complete successfully: exit code: 1
```