### PR TITLE
fix: notable not showing users for user-owned repositories

### DIFF
--- a/source/plugins/notable/index.mjs
+++ b/source/plugins/notable/index.mjs
@@ -109,7 +109,7 @@ export default async function({login, q, imports, rest, graphql, data, account, 
     console.debug(`metrics/compute/${login}/plugins > notable > aggregating results`)
     const aggregated = new Map()
     for (const {name, handle, avatar, organization = handle.split("/").shift() ?? "", stars, ..._extras} of contributions) {
-      const key = repositories ? handle : name
+      const key = !organization || repositories ? handle : name
       if (aggregated.has(key)) {
         const aggregate = aggregated.get(key)
         aggregate.aggregated++


### PR DESCRIPTION
This fixes https://github.com/lowlighter/metrics/discussions/1721:

![image](https://github.com/user-attachments/assets/96bb1733-8edd-45a4-9cf5-3c660ec0bd44)
