### PR TITLE
fix: undefined commit

### DIFF
--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -67,7 +67,7 @@ export class RecentAnalyzer extends Analyzer {
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
-          .filter(({committer}) => filters.text(committer?.email, this.authoring, {debug: false}))
+          .filter((commit) => commit?.committer?.email && filters.text(commit.committer.email, this.authoring, {debug: false}))
           .map(commit => commit.url)
           .map(async commit => (await this.rest.request(commit)).data),
       ),

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -67,7 +67,7 @@ export class RecentAnalyzer extends Analyzer {
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
-          .filter((commit) => commit?.committer?.email && filters.text(commit.committer.email, this.authoring, {debug: false}))
+          .filter((commit) => commit?.committer && filters.text(commit.committer.email, this.authoring, {debug: false}))
           .map(commit => commit.url)
           .map(async commit => (await this.rest.request(commit)).data),
       ),


### PR DESCRIPTION
Getting an error from github workflow:

```ts
TypeError: Cannot destructure property 'committer' of 'undefined' as it is undefined.
    at file:///metrics/source/plugins/languages/analyzer/recent.mjs:70:21
    at Array.filter (<anonymous>)
    at RecentAnalyzer.patches (file:///metrics/source/plugins/languages/analyzer/recent.mjs:70:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RecentAnalyzer.analyze (file:///metrics/source/plugins/languages/analyzer/recent.mjs:25:21)
    at async file:///metrics/source/plugins/languages/analyzer/recent.mjs:19:7
    at async results (file:///metrics/source/plugins/languages/analyzer/analyzer.mjs:63:7)
  ```

This solves that.