### PR TITLE
WIP: Fix recent languages after GitHub API change (Cannot destructure property 'committer' of 'undefined')

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-bookworm-slim AS base
 
 # Setup
-RUN  \
+RUN echo -n \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
   && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 # Base image
-FROM node:20-bookworm-slim
-
-# Copy repository
-COPY . /metrics
-WORKDIR /metrics
+FROM node:20-bookworm-slim AS base
 
 # Setup
-RUN chmod +x /metrics/source/app/action/index.mjs \
+RUN  \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
   # Based on https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
   && apt-get update \
@@ -24,7 +20,16 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install python for node-gyp
   && apt-get install -y python3 \
   # Clean apt/lists
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* 
+
+
+FROM base
+
+# Copy repository
+COPY . /metrics
+WORKDIR /metrics
+
+RUN chmod +x /metrics/source/app/action/index.mjs\
   # Install node modules and rebuild indexes
   && npm ci \
   && npm run build

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -76,6 +76,7 @@ export class RecentAnalyzer extends Analyzer {
       try {
         for (let page = 1; page <= pages; page++) {
           this.debug(`fetching commits page ${page}`)
+          this.debug(`https://api.github.com/repos/${item.repo}/git/commits?sha=${item.ref}&per_page=20&page=${page}`)
           commits.push(
             ...(await this.rest.request(`https://api.github.com/repos/${item.repo}/git/commits?sha=${item.ref}&per_page=20&page=${page}`)).data
               .map(x => { item.commits = item.commits.filter(c => c != x.sha); return x })

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -60,16 +60,16 @@ export class RecentAnalyzer extends Analyzer {
     }
     this.debug(`fetched ${events.length} events`)
 
-    const wanted = new Map();
+    const wanted = new Map()
     events.forEach(event => {
-      var key = `${event.repo.name}@${event.payload.ref}`
-      var item = wanted.get(key) ?? { commits: [] }
+      let key = `${event.repo.name}@${event.payload.ref}`
+      let item = wanted.get(key) ?? { commits: [] }
       item.repo = event.repo.name
       item.ref = event.payload.ref
       item.commits.push(event.payload.before)
       item.commits.push(event.payload.head)
       wanted.set(key, item)
-    });
+    })
 
     const commits = []
     for (const item of wanted.values()) {
@@ -79,7 +79,10 @@ export class RecentAnalyzer extends Analyzer {
           this.debug(`https://api.github.com/repos/${item.repo}/commits?sha=${item.ref}&per_page=20&page=${page}`)
           commits.push(
             ...(await this.rest.request(`https://api.github.com/repos/${item.repo}/commits?sha=${item.ref}&per_page=20&page=${page}`)).data
-              .map(x => { item.commits = item.commits.filter(c => c != x.sha); return x })
+              .map(x => {
+                item.commits = item.commits.filter(c => c !== x.sha)
+                return x
+              })
               .filter(({ committer }) => (this.account === "organization") || (this.context.mode === "repository") ? true : !filters.text(committer.login, [this.login], { debug: false }))
               .filter(({ commit }) => ((!this.days) || (new Date(commit.committer.date) > new Date(Date.now() - this.days * 24 * 60 * 60 * 1000)))),
           )
@@ -93,8 +96,6 @@ export class RecentAnalyzer extends Analyzer {
         this.debug("no more page to load")
       }
     }
-
-
 
     this.debug(`fetched ${commits.length} commits`)
     this.results.latest = Math.round((new Date().getTime() - new Date(events.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -76,9 +76,9 @@ export class RecentAnalyzer extends Analyzer {
       try {
         for (let page = 1; page <= pages; page++) {
           this.debug(`fetching commits page ${page}`)
-          this.debug(`https://api.github.com/repos/${item.repo}/git/commits?sha=${item.ref}&per_page=20&page=${page}`)
+          this.debug(`https://api.github.com/repos/${item.repo}/commits?sha=${item.ref}&per_page=20&page=${page}`)
           commits.push(
-            ...(await this.rest.request(`https://api.github.com/repos/${item.repo}/git/commits?sha=${item.ref}&per_page=20&page=${page}`)).data
+            ...(await this.rest.request(`https://api.github.com/repos/${item.repo}/commits?sha=${item.ref}&per_page=20&page=${page}`)).data
               .map(x => { item.commits = item.commits.filter(c => c != x.sha); return x })
               .filter(({ committer }) => (this.account === "organization") || (this.context.mode === "repository") ? true : !filters.text(committer.login, [this.login], { debug: false }))
               .filter(({ commit }) => ((!this.days) || (new Date(commit.committer.date) > new Date(Date.now() - this.days * 24 * 60 * 60 * 1000)))),

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -61,7 +61,10 @@ export class RecentAnalyzer extends Analyzer {
     this.results.latest = Math.round((new Date().getTime() - new Date(commits.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
     this.results.commits = commits.length
 
-    this.debug(JSON.stringify(commits));
+    commits.forEach(commit => {
+      this.debug(JSON.stringify(commit));
+    });
+    
     //Retrieve edited files and filter edited lines (those starting with +/-) from patches
     this.debug("fetching patches")
     const patches = [

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -61,6 +61,7 @@ export class RecentAnalyzer extends Analyzer {
     this.results.latest = Math.round((new Date().getTime() - new Date(commits.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
     this.results.commits = commits.length
 
+    this.debug(JSON.stringify(commits));
     //Retrieve edited files and filter edited lines (those starting with +/-) from patches
     this.debug("fetching patches")
     const patches = [

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -97,7 +97,7 @@ export class RecentAnalyzer extends Analyzer {
 
 
     this.debug(`fetched ${commits.length} commits`)
-    this.results.latest = Math.round((new Date().getTime() - new Date(commits.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
+    this.results.latest = Math.round((new Date().getTime() - new Date(events.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
     this.results.commits = commits.length
 
     //Retrieve edited files and filter edited lines (those starting with +/-) from patches

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -100,16 +100,11 @@ export class RecentAnalyzer extends Analyzer {
     this.results.latest = Math.round((new Date().getTime() - new Date(commits.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
     this.results.commits = commits.length
 
-    commits.forEach(commit => {
-      this.debug(JSON.stringify(commit));
-    });
-    
     //Retrieve edited files and filter edited lines (those starting with +/-) from patches
     this.debug("fetching patches")
     const patches = [
       ...await Promise.allSettled(
         commits
-          .flatMap(({payload}) => payload.commits)
           .filter(({committer}) => filters.text(committer?.email, this.authoring, {debug: false}))
           .map(commit => commit.url)
           .map(async commit => (await this.rest.request(commit)).data),
@@ -118,9 +113,9 @@ export class RecentAnalyzer extends Analyzer {
       .filter(({status}) => status === "fulfilled")
       .map(({value}) => value)
       .filter(({parents}) => parents.length <= 1)
-      .map(({sha, commit: {message, committer}, verification, files}) => ({
+      .map(({ sha, commit: { message, author }, verification, files }) => ({
         sha,
-        name: `${message} (authored by ${committer.name} on ${committer.date})`,
+        name: `${message} (authored by ${author.name} on ${author.date})`,
         verified: verification?.verified ?? null,
         editions: files.map(({filename, patch = ""}) => {
           const edition = {

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -72,7 +72,7 @@ export class RecentAnalyzer extends Analyzer {
     });
 
     const commits = []
-    for ([key, item] of wanted) {
+    for (const item of wanted.values()) {
       try {
         for (let page = 1; page <= pages; page++) {
           this.debug(`fetching commits page ${page}`)

--- a/source/plugins/languages/analyzer/recent.mjs
+++ b/source/plugins/languages/analyzer/recent.mjs
@@ -30,7 +30,7 @@ export class RecentAnalyzer extends Analyzer {
   async patches() {
     //Fetch commits from recent activity
     this.debug(`fetching patches from last ${this.days || ""} days up to ${this.load || "∞"} events`)
-    const commits = [], pages = Math.ceil((this.load || Infinity) / 100)
+    const pages = Math.ceil((this.load || Infinity) / 100)
     if (this.context.mode === "repository") {
       try {
         const {data: {default_branch: branch}} = await this.rest.repos.get(this.context)
@@ -42,10 +42,11 @@ export class RecentAnalyzer extends Analyzer {
         this.debug(`failed to get default branch for ${this.context.owner}/${this.context.repo} (${error})`)
       }
     }
+    const events = []
     try {
       for (let page = 1; page <= pages; page++) {
         this.debug(`fetching events page ${page}`)
-        commits.push(
+        events.push(
           ...(await (this.context.mode === "repository" ? this.rest.activity.listRepoEvents(this.context) : this.rest.activity.listEventsForAuthenticatedUser({username: this.login, per_page: 100, page}))).data
             .filter(({type, payload}) => (type === "PushEvent") && ((this.context.mode !== "repository") || ((this.context.mode === "repository") && (payload?.ref?.includes?.(`refs/heads/${this.context.branch}`)))))
             .filter(({actor}) => (this.account === "organization") || (this.context.mode === "repository") ? true : !filters.text(actor.login, [this.login], {debug: false}))
@@ -57,6 +58,43 @@ export class RecentAnalyzer extends Analyzer {
     catch {
       this.debug("no more page to load")
     }
+    this.debug(`fetched ${events.length} events`)
+
+    const wanted = new Map();
+    events.forEach(event => {
+      var key = `${event.repo.name}@${event.payload.ref}`
+      var item = wanted.get(key) ?? { commits: [] }
+      item.repo = event.repo.name
+      item.ref = event.payload.ref
+      item.commits.push(event.payload.before)
+      item.commits.push(event.payload.head)
+      wanted.set(key, item)
+    });
+
+    const commits = []
+    for ([key, item] of wanted) {
+      try {
+        for (let page = 1; page <= pages; page++) {
+          this.debug(`fetching commits page ${page}`)
+          commits.push(
+            ...(await this.rest.request(`https://api.github.com/repos/${item.repo}/git/commits?sha=${item.ref}&per_page=20&page=${page}`)).data
+              .map(x => { item.commits = item.commits.filter(c => c != x.sha); return x })
+              .filter(({ committer }) => (this.account === "organization") || (this.context.mode === "repository") ? true : !filters.text(committer.login, [this.login], { debug: false }))
+              .filter(({ commit }) => ((!this.days) || (new Date(commit.committer.date) > new Date(Date.now() - this.days * 24 * 60 * 60 * 1000)))),
+          )
+          if (item.commits < 1) {
+            this.debug("found expected commits")
+            break
+          }
+        }
+      }
+      catch {
+        this.debug("no more page to load")
+      }
+    }
+
+
+
     this.debug(`fetched ${commits.length} commits`)
     this.results.latest = Math.round((new Date().getTime() - new Date(commits.slice(-1).shift()?.created_at).getTime()) / (1000 * 60 * 60 * 24))
     this.results.commits = commits.length
@@ -108,15 +146,15 @@ export class RecentAnalyzer extends Analyzer {
   }
 
   /**Run linguist against a commit and compute edited lines and bytes*/
-  async linguist(_, {commit, cache: {languages}}) {
-    const cache = {files: {}, languages}
-    const result = {total: 0, files: 0, missed: {lines: 0, bytes: 0}, lines: {}, stats: {}, languages: {}}
+  async linguist(_, { commit, cache: { languages } }) {
+    const cache = { files: {}, languages }
+    const result = { total: 0, files: 0, missed: { lines: 0, bytes: 0 }, lines: {}, stats: {}, languages: {} }
     const edited = new Set()
     for (const edition of commit.editions) {
       edited.add(edition.path)
 
       //Guess file language with linguist
-      const {files: {results: files}, languages: {results: languages}, unknown} = await linguist(edition.path, {fileContent: edition.patch})
+      const { files: { results: files }, languages: { results: languages }, unknown } = await linguist(edition.path, { fileContent: edition.patch })
       Object.assign(cache.files, files)
       Object.assign(cache.languages, languages)
       if (!(edition.path in cache.files))


### PR DESCRIPTION
:warning: This is a working branch, and not intended for direct merging.
It is provided for discussion and community visibility. The quality of this code is not suitable for merging as-is.

---
This PR fixes the following error causing failure to update svg and failed action runs;
```javascript
 file:///metrics/source/app/action/index.mjs:15
  throw error
  ^

TypeError: Cannot destructure property 'committer' of 'undefined' as it is undefined.
    at file:///metrics/source/plugins/languages/analyzer/recent.mjs:70:21
    at Array.filter (<anonymous>)
    at RecentAnalyzer.patches (file:///metrics/source/plugins/languages/analyzer/recent.mjs:70:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RecentAnalyzer.analyze (file:///metrics/source/plugins/languages/analyzer/recent.mjs:25:21)
    at async file:///metrics/source/plugins/languages/analyzer/recent.mjs:19:7
    at async results (file:///metrics/source/plugins/languages/analyzer/analyzer.mjs:63:7)
 ```

---

GitHub recently changed the APIs used to get some of the commit information used in the recent languages portion of the code. API version was not bumped, and the breaking changes documentation was not updated, so it took me a while to figure out what had gone wrong. Once I did, however, I found this blog post that *hints* at what they where doing and why; https://github.blog/changelog/2025-08-08-upcoming-changes-to-github-events-api-payloads/

Specifically, this part of the `PushEvent` no longer exists:
https://github.com/lowlighter/metrics/blob/582a522ffd4e9efb2178c956fccea610f418cd08/tests/mocks/api/github/rest/activity/listEventsForAuthenticatedUser.mjs#L271-L280

I'm not familiar with the code base, nor particularly familiar with the code style (additionally, auto-formatter managed to sneak in some whitespace – ignore that.), so the implementation may not be the best. I'm fairly certain that I managed to re-implement it properly however.

Do note the change from using committer to author in the authored by message, as committer would be GitHub for any file edited in the web interface (but set to the appropriate info in the authored structure). Not sure if that string is used anywhere, but that seemed more correct.

I am trying to do some smarts here in how many pages of commits we retrieve, based on the commits the event listed as head and base (we could use those two fields to get the patch of the changeset, but then we couldn't filter author on a commit-by-commit basis `gh api -H "Accept: application/vnd.github.patch" /repos/oddstr13/github-profile-metrics/compare/c32878ca41906dba3e10fc9f19b2b12bc4298cd8...de58e40391d57e531a9e7330f7935d3637f85efd`).

This branch contain unrelated changes, mainly in the dockerfile, as this is my testing branch (and what is currently used to update my profile badge).

---

Closes #1753 as it only hides the exception

#1739 is related, in that it seems to be hiding the same issue in a different part of the code base, I have not looked into this yet, but that PR doesn't fix the underlying issue either, just hides it