### PR TITLE
fix(habits): handle commits without author to prevent undefined destr…

### DIFF
--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -48,6 +48,7 @@ export default async function({login, data, rest, imports, q, account}, {enabled
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
+          .filter(commit => commit?.author)
           .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring) || author?.email?.toLocaleLowerCase().includes(authoring) || author?.name?.toLocaleLowerCase().includes(authoring)).length)
           .map(async commit => (await rest.request(commit)).data.files),
       ),


### PR DESCRIPTION
## Description
Fixes an issue where the habits plugin crashes when encountering commits without an `author` property, which can occur with:
- Bot commits
- System-generated events
- Merge commits from certain workflows
- Archived repositories

## Changes
- Added a filter to check if `commit?.author` exists before destructuring
- Prevents `TypeError: Cannot destructure property 'author' of 'undefined'`

## Testing
Tested with repositories containing fork commits and automated merge events.

## Related Issue
Fixes the error: `TypeError: Cannot destructure property 'author' of 'undefined' at file:///metrics/source/plugins/habits/index.mjs:51:21`