### PR TITLE
fix(habits): add null check for commit author property

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   && apt-get install -y curl unzip \
   && curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr/local sh \
   # Install ruby to support github licensed gem
-  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev \
+  && apt-get install -y ruby-full git g++ cmake pkg-config libssl-dev xz-utils libxml2-dev libxslt-dev \
   && gem install licensed \
   # Install python for node-gyp
   && apt-get install -y python3 \

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -48,7 +48,7 @@ export default async function({login, data, rest, imports, q, account}, {enabled
       ...await Promise.allSettled(
         commits
           .flatMap(({payload}) => payload.commits)
-          .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring) || author?.email?.toLocaleLowerCase().includes(authoring) || author?.name?.toLocaleLowerCase().includes(authoring)).length)
+          .filter(commit => commit?.author && data.shared["commits.authoring"].filter(authoring => commit.author?.login?.toLocaleLowerCase().includes(authoring) || commit.author?.email?.toLocaleLowerCase().includes(authoring) || commit.author?.name?.toLocaleLowerCase().includes(authoring)).length)
           .map(async commit => (await rest.request(commit)).data.files),
       ),
     ]


### PR DESCRIPTION
## Description

This PR fixes a TypeError that occurs when the GitHub API returns events with commits that don't have an `author` property defined.

## Problem

The habits plugin crashes with the following error:

```
TypeError: Cannot destructure property 'author' of 'undefined' as it is undefined.
    at file:///metrics/source/plugins/habits/index.mjs:51:21
    at Array.filter (<anonymous>)
```

This happens because some commits returned by the GitHub Events API don't have the `author` property (e.g., commits from deleted users, bots, or malformed API responses).

## Solution

Added a null check before accessing the `author` property in the filter callback:

```javascript
// Before
.filter(({author}) => data.shared["commits.authoring"].filter(...).length)

// After
.filter(commit => commit?.author && data.shared["commits.authoring"].filter(...).length)
```

## Testing

- Tested with a GitHub profile that was previously failing with this error
- The habits plugin now works correctly and gracefully skips commits without author data

## Related Issues

Fixes users experiencing "Cannot destructure property 'author' of 'undefined'" errors when using the habits plugin.

