### PR TITLE
feat(plugins/notable): add plugin_notable_organizations_skipped param…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -807,6 +807,10 @@ inputs:
     description: Skipped repositories
     default: <default-value>
 
+  plugin_notable_organizations_skipped:
+    description: Skipped organizations
+    default: <default-value>
+
   plugin_notable_from:
     description: Repository owner account type filter
     default: <default-value>

--- a/source/app/metrics/utils.mjs
+++ b/source/app/metrics/utils.mjs
@@ -417,6 +417,43 @@ export const filters = {
       console.debug(`metrics/filters/repo > filter ${repo} (${include ? "included" : "excluded"})`)
     return include
   },
+  /**Organization filter (exclusion list, same semantics as repo) */
+  organization(organizationLogin, patterns, {debug = true} = {}) {
+    if (!patterns.length)
+      return true
+
+    const org = `${organizationLogin}`.toLocaleLowerCase()
+
+    let include = true
+    if (patterns[0] === "@use.patterns") {
+      if (debug)
+        console.debug(`metrics/filters/organization > ${org} > using advanced pattern matching`)
+      const options = {nocase: true}
+      for (let pattern of patterns) {
+        if (pattern.startsWith("#"))
+          continue
+        let action = false
+        if ((pattern.startsWith("+")) || (pattern.startsWith("-"))) {
+          action = pattern.charAt(0) === "+"
+          pattern = pattern.substring(1)
+        }
+        if (minimatch(org, pattern, options)) {
+          if (debug)
+            console.debug(`metrics/filters/organization > ${org} matches ${action ? "including" : "excluding"} pattern ${pattern}`)
+          include = action
+        }
+      }
+    }
+    else {
+      if (debug)
+        console.debug(`metrics/filters/organization > ${org} > using basic pattern matching`)
+      include = !patterns.includes(org)
+    }
+
+    if (debug)
+      console.debug(`metrics/filters/organization > filter ${org} (${include ? "included" : "excluded"})`)
+    return include
+  },
   /**Text filter*/
   text(text, patterns, {debug = true} = {}) {
     //Disable filtering when no pattern is provided

--- a/source/plugins/notable/README.md
+++ b/source/plugins/notable/README.md
@@ -69,6 +69,17 @@ Some repositories may not be able to reported advanced stats and in the case the
 <br></td>
   </tr>
   <tr>
+    <td nowrap="nowrap"><h4><code>plugin_notable_organizations_skipped</code></h4></td>
+    <td rowspan="2"><p>Skipped organizations. Exclude contributions from these organizations in both badges and repository lists. Supports the same pattern syntax as <code>plugin_notable_skipped</code> (basic and <code>@use.patterns</code> with minimatch for wildcards, e.g. <code>org-*</code>).</p>
+<img width="900" height="1" alt=""></td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap"><b>type:</b> <code>array</code>
+<i>(newline-separated)</i>
+<br>
+<b>default:</b> ""<br></td>
+  </tr>
+  <tr>
     <td nowrap="nowrap"><h4><code>plugin_notable_from</code></h4></td>
     <td rowspan="2"><p>Repository owner account type filter</p>
 <ul>
@@ -158,6 +169,19 @@ with:
   token: ${{ secrets.METRICS_TOKEN }}
   base: ""
   plugin_notable: yes
+
+```
+```yaml
+name: Contributions (excluding organizations)
+uses: lowlighter/metrics@latest
+with:
+  filename: metrics.plugin.notable.svg
+  token: ${{ secrets.METRICS_TOKEN }}
+  base: ""
+  plugin_notable: yes
+  plugin_notable_organizations_skipped: |
+    my-org
+    other-org
 
 ```
 ```yaml

--- a/source/plugins/notable/index.mjs
+++ b/source/plugins/notable/index.mjs
@@ -7,7 +7,7 @@ export default async function({login, q, imports, rest, graphql, data, account, 
       return null
 
     //Load inputs
-    let {filter, skipped, repositories, types, from, indepth, self} = imports.metadata.plugins.notable.inputs({data, account, q})
+    let {filter, skipped, "organizations.skipped": organizationsSkipped = [], repositories, types, from, indepth, self} = imports.metadata.plugins.notable.inputs({data, account, q})
     skipped.push(...data.shared["repositories.skipped"])
 
     //Iterate through contributed repositories
@@ -21,6 +21,7 @@ export default async function({login, q, imports, rest, graphql, data, account, 
         cursor = edges?.[edges?.length - 1]?.cursor
         edges
           .filter(({node}) => imports.filters.repo(node, skipped))
+          .filter(({node}) => !node.isInOrganization || imports.filters.organization(node.owner.login, organizationsSkipped))
           .filter(({node}) => ({all: true, organization: node.isInOrganization, user: !node.isInOrganization}[from]))
           .filter(({node}) => imports.filters.github(filter, {name: node.nameWithOwner, user: node.owner.login, stars: node.stargazers.totalCount, watchers: node.watchers.totalCount, forks: node.forks.totalCount}))
           .map(({node}) => contributions.push({handle: node.nameWithOwner, stars: node.stargazers.totalCount, issues: node.issues.totalCount, pulls: node.pullRequests.totalCount, organization: node.isInOrganization, avatarUrl: node.owner.avatarUrl}))

--- a/source/plugins/notable/metadata.yml
+++ b/source/plugins/notable/metadata.yml
@@ -42,6 +42,19 @@ inputs:
     example: my-repo-1, my-repo-2, owner/repo-3, ...
     inherits: repositories_skipped
 
+  plugin_notable_organizations_skipped:
+    description: |
+      Skipped organizations
+
+      Exclude contributions from these organizations in both badges and repository lists.
+      Supports the same pattern syntax as [`plugin_notable_skipped`](/source/plugins/notable/README.md#plugin_notable_skipped) (basic and `@use.patterns` with minimatch for wildcards, e.g. `org-*`).
+    type: array
+    format:
+      - newline-separated
+      - comma-separated
+    default: ""
+    example: my-org, other-org, ...
+
   plugin_notable_from:
     description: |
       Repository owner account type filter


### PR DESCRIPTION
## Summary

Adds `plugin_notable_organizations_skipped` parameter to exclude specific organizations from the Notable contributions plugin.

## Motivation

Users with private organization memberships want to hide these organizations from their public GitHub profile metrics while keeping their other notable contributions visible.

**Use case:** A developer contributes to a private company organization but wants to showcase only public open-source contributions on their profile.

## Changes

- Added `plugin_notable_organizations_skipped` parameter in:
  - `action.yml` - GitHub Action input declaration
  - `source/plugins/notable/metadata.yml` - Plugin metadata
  - `source/plugins/notable/README.md` - User documentation with example
- Implemented `organization()` filter function in `source/app/metrics/utils.mjs`
  - Follows same pattern matching logic as existing `repo()` filter
  - Supports both basic and advanced patterns (`@use.patterns` with minimatch)
- Applied filter in `source/plugins/notable/index.mjs` to exclude organizations from both badges and repository lists

## Example Usage
```yaml
- uses: lowlighter/metrics@latest
  with:
    plugin_notable: yes
    plugin_notable_organizations_skipped: |
      private-company
      internal-org
```

**Advanced pattern matching:**
```yaml
plugin_notable_organizations_skipped: |
  @use.patterns
  -company-*
  -internal-*
```

## Testing

- Tested on personal profile with private organization membership
- Organizations are correctly filtered from both organization badges and repository lists
- Backward compatible - works without the parameter (default behavior unchanged)
- Supports wildcards and advanced pattern matching