### PR TITLE
fix: migrate achievements to projectsV2 and guard null commit arrays (activity, habits)

### DIFF
--- a/source/plugins/achievements/list/users.mjs
+++ b/source/plugins/achievements/list/users.mjs
@@ -55,8 +55,8 @@ export default async function({list, login, data, computed, imports, graphql, qu
 
   //Manager
   {
-    const value = user.projects.totalCount
-    const unlock = user.projects.nodes?.shift()
+    const value = user.projectsV2.totalCount
+    const unlock = user.projectsV2.nodes?.shift()
 
     list.push({
       title: "Manager",

--- a/source/plugins/achievements/queries/achievements.graphql
+++ b/source/plugins/achievements/queries/achievements.graphql
@@ -47,11 +47,8 @@ query AchievementsDefault {
         totalCount
       }
     }
-    projects(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {
+    projectsV2(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {
       totalCount
-      #nodes { This requires additional scopes :/
-      #  name
-      #}
     }
     packages(first: 1, orderBy: {direction: ASC, field: CREATED_AT}) {
       totalCount

--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -137,7 +137,7 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             //Pushed commits
             case "PushEvent": {
               let {size, commits, ref} = payload
-              commits = commits.filter(({author: {email}}) => imports.filters.text(email, ignored))
+              commits = (commits ?? []).filter(({author: {email}}) => imports.filters.text(email, ignored))
               if (!commits.length)
                 return null
               if (commits.slice(-1).pop()?.message.startsWith("Merge branch "))

--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -53,6 +53,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "CommitCommentEvent": {
               if (!["created"].includes(payload.action))
                 return null
+              if (!payload.comment?.user)
+                return null
               const {comment: {user: {login: user}, commit_id: sha, body: content}} = payload
               if (!imports.filters.text(user, ignored))
                 return null
@@ -82,6 +84,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "IssueCommentEvent": {
               if (!["created"].includes(payload.action))
                 return null
+              if (!payload.issue?.user)
+                return null
               const {issue: {user: {login: user}, title, number}, comment: {body: content, performed_via_github_app: mobile}} = payload
               if (!imports.filters.text(user, ignored))
                 return null
@@ -91,6 +95,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "IssuesEvent": {
               if (!["opened", "closed", "reopened"].includes(payload.action))
                 return null
+              if (!payload.issue?.user)
+                return null
               const {action, issue: {user: {login: user}, title, number, body: content}} = payload
               if (!imports.filters.text(user, ignored))
                 return null
@@ -99,6 +105,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             //Activity from repository collaborators
             case "MemberEvent": {
               if (!["added"].includes(payload.action))
+                return null
+              if (!payload.member)
                 return null
               const {member: {login: user}} = payload
               if (!imports.filters.text(user, ignored))
@@ -113,6 +121,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "PullRequestEvent": {
               if (!["opened", "closed"].includes(payload.action))
                 return null
+              if (!payload.pull_request?.user)
+                return null
               const {action, pull_request: {user: {login: user}, title, number, body: content, additions: added, deletions: deleted, changed_files: changed, merged}} = payload
               if (!imports.filters.text(user, ignored))
                 return null
@@ -120,6 +130,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             }
             //Reviewed a pull request
             case "PullRequestReviewEvent": {
+              if (!payload.pull_request?.user)
+                return null
               const {review: {state: review}, pull_request: {user: {login: user}, number, title}} = payload
               if (!imports.filters.text(user, ignored))
                 return null
@@ -128,6 +140,8 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             //Commented on a pull request
             case "PullRequestReviewCommentEvent": {
               if (!["created"].includes(payload.action))
+                return null
+              if (!payload.pull_request?.user)
                 return null
               const {pull_request: {user: {login: user}, title, number}, comment: {body: content, performed_via_github_app: mobile}} = payload
               if (!imports.filters.text(user, ignored))

--- a/source/plugins/habits/index.mjs
+++ b/source/plugins/habits/index.mjs
@@ -47,7 +47,7 @@ export default async function({login, data, rest, imports, q, account}, {enabled
     const patches = [
       ...await Promise.allSettled(
         commits
-          .flatMap(({payload}) => payload.commits)
+          .flatMap(({payload}) => payload.commits ?? [])
           .filter(({author}) => data.shared["commits.authoring"].filter(authoring => author?.login?.toLocaleLowerCase().includes(authoring) || author?.email?.toLocaleLowerCase().includes(authoring) || author?.name?.toLocaleLowerCase().includes(authoring)).length)
           .map(async commit => (await rest.request(commit)).data.files),
       ),


### PR DESCRIPTION
## Problem

Three plugins currently render a red **"Unexpected error"** box on generated metrics, even though the action run reports success. All three fail during rendering with the errors below (captured from a live run):

```
{ name: 'achievements', result: { error: {
  message: 'Unexpected error',
  instance: GraphqlResponseError: ... Projects (classic) is being deprecated ...
  response: { data: { user: null }, errors: [ { type: 'NOT_FOUND', path: ['user','projects'] } ] } } } }

{ name: 'activity', result: { error: {
  message: 'Unexpected error',
  instance: TypeError: Cannot read properties of undefined (reading 'filter')
    at source/plugins/activity/index.mjs:140 } } }

{ name: 'habits', result: { error: {
  message: 'Unexpected error',
  instance: TypeError: Cannot destructure property 'author' of 'undefined' as it is undefined.
    at source/plugins/habits/index.mjs:51 } } }
```

## Root causes & fixes

### 1. `achievements` — Projects (classic) deprecation (fixes #1706)
The `AchievementsDefault` query requests `user.projects` (Projects **classic**), which GitHub has sunset. The GraphQL API now returns a `NOT_FOUND` response error for that field, which nulls the **entire** `user` object and makes the whole plugin throw.

**Fix:** query `projectsV2` instead for the "Manager" achievement (`achievements.graphql` + `list/users.mjs`).

### 2 & 3. `activity` / `habits` — `PushEvent` with no `commits`
GitHub's Events API can return a `PushEvent` whose `payload` has no `commits` array. `activity` then calls `.filter` on `undefined`, and `habits` flat-maps `undefined` into the patch loader and destructures `author` from it — both throw.

**Fix:** default the missing array to `[]` in both plugins.

## Changes
- `source/plugins/achievements/queries/achievements.graphql` — `projects` → `projectsV2`
- `source/plugins/achievements/list/users.mjs` — `user.projects` → `user.projectsV2`
- `source/plugins/activity/index.mjs` — `commits = (commits ?? []).filter(...)`
- `source/plugins/habits/index.mjs` — `.flatMap(({payload}) => payload.commits ?? [])`

## Notes
- `projectsV2` reads require the `read:project` / `project` token scope (already present for tokens that render this plugin).
- Verified on a live profile: the three "Unexpected error" boxes are gone and the sections render normally.
