### PR TITLE
ci(docker): move base image from end-of-life node:20 to node:24 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:20-bookworm-slim
+FROM node:24-bookworm-slim
 
 # Copy repository
 COPY . /metrics


### PR DESCRIPTION
Hello, and thank you for *metrics* — it's a lovely project.

This is a one-line change to `Dockerfile`, and I've tried to explain the reasoning fully so it's easy to reject if you disagree.

## The change

```diff
-FROM node:20-bookworm-slim
+FROM node:24-bookworm-slim
```

## Why

**Node 20 reached end-of-life on 2026-04-30.** Currently supported lines are 22, 24 and 26. I picked **24** because it's the current active LTS — 22 is in maintenance, and 26 is Current rather than LTS. If you'd rather go to 22 or 26, I'm happy to change it.

The reason end-of-life matters more than "it's a bit old" is that Node states the consequence itself, in its security-release notes:

> "It's important to note that **End-of-Life versions are always affected** when a security release occurs."

The June 2026 security release fixed twelve CVEs, patched into 22.x / 24.x / 26.x only. Two are HIGH:

| CVE | | |
|---|---|---|
| CVE-2026-48933 | HIGH | WebCrypto AES integer overflow → remote process abort |
| CVE-2026-48618 | HIGH | Unicode dot separator → TLS wildcard-depth authentication bypass |
| CVE-2026-48934 | Medium | TLS host identity verification bypass via session reuse |
| CVE-2026-48928 | Medium | Uppercase SNI matching → mTLS authorization bypass |
| CVE-2026-48615 | Medium | Proxy credentials leaked in an `ERR_PROXY_TUNNEL` message |

The July 2026 release did the same — 26.x/24.x/22.x only. Because `metrics` is a Docker action, this image is built and run inside consumers' workflows, so the runtime line propagates to everyone who uses it.

## Why nothing flagged this

`node:20-bookworm-slim` keeps resolving perfectly well. It simply stops receiving fixes, and nothing announces that.

Concretely for this repo: `.github/dependabot.yml` configures the **`npm`** ecosystem only — there's no `docker` entry, so nothing is watching `FROM` lines at all. Even with one, GitHub documents the `docker` ecosystem as supporting *version* updates but **not security updates**. So this is a genuine blind spot rather than anything anyone overlooked.

## What I did NOT verify — please read this before merging

**I did not build the image.** I have no way to confirm that `npm ci && npm run build`, the native `node-gyp` modules, and Puppeteer all behave identically on Node 24. `package.json` declares no `engines` field, so there's no stated constraint either way, but a major Node jump can surface native-module rebuild issues. **Your CI is the real check here, not me.** If it goes red, the honest answer may be that 22 is the safer step.

I also didn't scan the published image or make any exploitability claim about the CVEs above — the narrower claim is that an end-of-life runtime ships and structurally cannot receive those fixes.

## On process

`CONTRIBUTING.md` suggests opening a discussion first to gather feedback. I read that as aimed at new features and hoped a one-line maintenance change was within the spirit of going straight to a PR — but if you'd prefer this as a discussion, say the word and I'll move it and close this.

*Disclosure: AI-assisted (Claude Opus 5). I read the Dockerfile and dependabot config myself, verified the Node EOL dates and the CVE list against nodejs.org and endoflife.date this session, and confirmed the `node:24-bookworm-slim` tag exists before proposing it.*
