### PR TITLE
fix(crypto): restore rendered example

### DIFF
--- a/source/plugins/community/crypto/examples.yml
+++ b/source/plugins/community/crypto/examples.yml
@@ -9,7 +9,5 @@
     plugin_crypto_vs_currency: usd
     plugin_crypto_days: 1
     plugin_crypto_precision: 2
-  prod:
-    skip: true
   test:
     skip: true

--- a/source/plugins/community/crypto/metadata.yml
+++ b/source/plugins/community/crypto/metadata.yml
@@ -5,7 +5,7 @@ description: |
   This plugin using coingecko API to fetch crypto prices.
   check https://www.coingecko.com/vi/api/documentation for more information.
 examples:
-  default: https://via.placeholder.com/468x60?text=No%20preview%20available
+  default: https://github.com/lowlighter/metrics/blob/examples/metrics.plugin.crypto.svg
 authors:
   - dajneem23
 supports:


### PR DESCRIPTION
## How I found this

I noticed that the **Crypto** section on the [Metrics Embed GitHub Marketplace page](https://github.com/marketplace/actions/metrics-embed) did not display anything when expanding **Render example**.

## Cause

The Crypto plugin metadata still referenced a `via.placeholder.com` placeholder instead of a generated example. That placeholder is no longer available. In addition, the Crypto example had `prod.skip: true`, so the examples workflow never generated `metrics.plugin.crypto.svg` on the `examples` branch.

## Solution

- Enable the Crypto example in the production examples workflow by removing `prod.skip`.
- Point the Crypto preview metadata to `metrics.plugin.crypto.svg` on the `examples` branch, consistently with the other plugins.
- Keep the test example skipped so regular tests do not depend on the external CoinGecko API.

Once merged, the repository build workflow will regenerate the derived README and examples workflow files, and the examples workflow can publish the SVG used by the Marketplace preview.

## Verification

- `npm run build`
- `npm run test-contrib` (26 tests passed)
- Confirmed the CoinGecko coin and market chart endpoints used by the plugin return HTTP 200.